### PR TITLE
Worker Resources in Condor Sched

### DIFF
--- a/src/funnel/scheduler/condor/sched.go
+++ b/src/funnel/scheduler/condor/sched.go
@@ -102,19 +102,19 @@ func (s *scheduler) StartWorker(w *pbf.Worker) error {
 	}
 
 	submitTpl, err := template.New("condor.submit").Parse(`
-		universe       = vanilla
-		executable     = {{.Executable}}
-		arguments      = worker --config worker.conf.yml
-		environment    = "PATH=/usr/bin"
-		log            = {{.WorkDir}}/condor-event-log
-		error          = {{.WorkDir}}/tes-worker-stderr
-		output         = {{.WorkDir}}/tes-worker-stdout
-		input          = {{.Config}}
-		{{.Resources}}
-		should_transfer_files   = YES
-		when_to_transfer_output = ON_EXIT
-		queue
-	`)
+universe       = vanilla
+executable     = {{.Executable}}
+arguments      = worker --config worker.conf.yml
+environment    = "PATH=/usr/bin"
+log            = {{.WorkDir}}/condor-event-log
+error          = {{.WorkDir}}/tes-worker-stderr
+output         = {{.WorkDir}}/tes-worker-stdout
+input          = {{.Config}}
+{{.Resources}}
+should_transfer_files   = YES
+when_to_transfer_output = ON_EXIT
+queue
+`)
 	if err != nil {
 		return err
 	}

--- a/src/funnel/scheduler/condor/sched.go
+++ b/src/funnel/scheduler/condor/sched.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 )
 
 var log = logger.New("condor")
@@ -84,8 +85,7 @@ func (s *scheduler) StartWorker(w *pbf.Worker) error {
 
 	c := s.conf.Worker
 	c.ID = w.Id
-	// 5 second timeout
-	c.Timeout = 5000000000
+	c.Timeout = 5 * time.Second
 	c.Resources.Cpus = w.Resources.Cpus
 	c.Resources.Ram = w.Resources.Ram
 	c.Resources.Disk = w.Resources.Disk

--- a/src/funnel/scheduler/condor/sched.go
+++ b/src/funnel/scheduler/condor/sched.go
@@ -20,7 +20,7 @@ var log = logger.New("condor")
 // prefix is a string prefixed to condor worker IDs, so that condor
 // workers can be identified by ShouldStartWorker() below.
 // TODO move to worker metadata to be consistent with GCE
-const prefix = "condor"
+const prefix = "condor-worker-"
 
 // NewScheduler returns a new HTCondor Scheduler instance.
 func NewScheduler(conf config.Config) sched.Scheduler {
@@ -35,17 +35,29 @@ type scheduler struct {
 func (s *scheduler) Schedule(j *tes.Job) *sched.Offer {
 	log.Debug("Running condor scheduler")
 
-	var disk float64
-	for _, v := range j.Task.GetResources().GetVolumes() {
-		disk += v.SizeGb
+	disk := s.conf.Worker.Resources.Disk
+	if disk == 0.0 {
+		for _, v := range j.Task.GetResources().GetVolumes() {
+			disk += v.GetSizeGb()
+		}
+	}
+
+	cpus := s.conf.Worker.Resources.Cpus
+	if cpus == 0 {
+		cpus = j.Task.GetResources().GetMinimumCpuCores()
+	}
+
+	ram := s.conf.Worker.Resources.Ram
+	if ram == 0.0 {
+		ram = j.Task.GetResources().GetMinimumRamGb()
 	}
 
 	// TODO could we call condor_submit --dry-run to test if a job would succeed?
 	w := &pbf.Worker{
-		Id: prefix + sched.GenWorkerID(prefix),
+		Id: prefix + j.JobID,
 		Resources: &pbf.Resources{
-			Cpus: j.Task.GetResources().GetMinimumCpuCores(),
-			Ram:  j.Task.GetResources().GetMinimumRamGb(),
+			Cpus: cpus,
+			Ram:  ram,
 			Disk: disk,
 		},
 	}
@@ -60,15 +72,20 @@ func (s *scheduler) ShouldStartWorker(w *pbf.Worker) bool {
 // StartWorker submits a job via "condor_submit" to start a new worker.
 func (s *scheduler) StartWorker(w *pbf.Worker) error {
 	log.Debug("Starting condor worker")
+	var err error
 
 	// TODO document that these working dirs need manual cleanup
 	workdir := path.Join(s.conf.WorkDir, w.Id)
 	workdir, _ = filepath.Abs(workdir)
-	os.MkdirAll(workdir, 0755)
+	err = os.MkdirAll(workdir, 0755)
+	if err != nil {
+		return err
+	}
 
 	c := s.conf.Worker
 	c.ID = w.Id
-	c.Timeout = 0
+	// 5 second timeout
+	c.Timeout = 5000000000
 	c.Resources.Cpus = w.Resources.Cpus
 	c.Resources.Ram = w.Resources.Ram
 	c.Resources.Disk = w.Resources.Disk
@@ -79,42 +96,67 @@ func (s *scheduler) StartWorker(w *pbf.Worker) error {
 	workerPath := sched.DetectWorkerPath()
 
 	submitPath := path.Join(workdir, "condor.submit")
-	f, _ := os.Create(submitPath)
+	f, err := os.Create(submitPath)
+	if err != nil {
+		return err
+	}
 
-	submitTpl, _ := template.New("condor.submit").Parse(`
+	submitTpl, err := template.New("condor.submit").Parse(`
 		universe       = vanilla
 		executable     = {{.Executable}}
 		arguments      = worker --config worker.conf.yml
 		environment    = "PATH=/usr/bin"
 		log            = {{.WorkDir}}/condor-event-log
-		error          = {{.WorkDir}}/funnel-worker-stderr
-		output         = {{.WorkDir}}/funnel-worker-stdout
-		input					 = {{.Config}}
-		request_cpus	 = {{.CPU}}
-		request_memory = {{.RAM}}
-		request_disk	 = {{.Disk}}
-		should_transfer_files		= YES
+		error          = {{.WorkDir}}/tes-worker-stderr
+		output         = {{.WorkDir}}/tes-worker-stdout
+		input          = {{.Config}}
+		{{.Resources}}
+		should_transfer_files   = YES
 		when_to_transfer_output = ON_EXIT
 		queue
 	`)
-	submitTpl.Execute(f, map[string]string{
+	if err != nil {
+		return err
+	}
+
+	err = submitTpl.Execute(f, map[string]string{
 		"Executable": workerPath,
 		"WorkDir":    workdir,
 		"Config":     confPath,
-		"CPU":        fmt.Sprintf("%d", w.Resources.Cpus),
-		"RAM":        fmt.Sprintf("%f GB", w.Resources.Ram),
-		// Convert GB to KiB
-		"Disk": fmt.Sprintf("%f", w.Resources.Disk*976562),
+		"Resources":  resolveCondorResourceRequest(int(w.Resources.Cpus), w.Resources.Ram, w.Resources.Disk),
 	})
+	if err != nil {
+		return err
+	}
 	f.Close()
 
 	cmd := exec.Command("condor_submit")
-	stdin, _ := os.Open(submitPath)
+	stdin, err := os.Open(submitPath)
+	if err != nil {
+		return err
+	}
 	cmd.Stdin = stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Run()
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
 
-	// TODO better error checking
 	return nil
+}
+
+func resolveCondorResourceRequest(cpus int, ram float64, disk float64) string {
+	var resources = []string{}
+	if cpus != 0 {
+		resources = append(resources, fmt.Sprintf("request_cpus = %d", cpus))
+	}
+	if ram != 0.0 {
+		resources = append(resources, fmt.Sprintf("request_memory = %f GB", ram))
+	}
+	if disk != 0.0 {
+		// Convert GB to KiB
+		resources = append(resources, fmt.Sprintf("request_disk = %f", disk*976562))
+	}
+	return strings.Join(resources, "\n")
 }


### PR DESCRIPTION
Worker resources are requested via condor_submit. 

Worker resources are inherited from the Task message since there is a 1-to-1 mapping between jobs and workers in this backend. 

If worker resources are set in the config this overrides all other behavior and all worker requests get these values. 
