### PR TITLE
Fix for worker CLI start

### DIFF
--- a/src/funnel/cmd/server.go
+++ b/src/funnel/cmd/server.go
@@ -57,9 +57,11 @@ func init() {
 }
 
 func startServer(conf config.Config) {
+	logger.SetLevel(conf.LogLevel)
+	workerLog.Debug("Server Config", "config.Config", conf)
+
 	var err error
 
-	logger.SetLevel(conf.LogLevel)
 	// TODO Good defaults, configuration, and reusable way to configure logging.
 	//      Also, how do we get this to default to /var/log/tes/worker.log
 	//      without having file permission problems?

--- a/src/funnel/cmd/worker.go
+++ b/src/funnel/cmd/worker.go
@@ -18,7 +18,6 @@ var workerBaseConf = config.Config{}
 var workerCmd = &cobra.Command{
 	Use:   "worker",
 	Short: "",
-	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		var wconf = config.WorkerDefaultConfig(config.DefaultConfig())
 		var conf config.Config
@@ -53,6 +52,7 @@ func init() {
 
 func startWorker(conf config.Worker) {
 	logger.SetLevel(conf.LogLevel)
+	workerLog.Debug("Worker Config", "config.Worker", conf)
 
 	// TODO Good defaults, configuration, and reusable way to configure logging.
 	//      Also, how do we get this to default to /var/log/tes/worker.log

--- a/src/funnel/config/config.go
+++ b/src/funnel/config/config.go
@@ -190,7 +190,9 @@ func WorkerDefaultConfig(c Config) Worker {
 
 // WorkerInheritConfigVals is a utility to help ensure the Worker inherits the proper config values from the parent Config
 func WorkerInheritConfigVals(c Config) Worker {
-	c.Worker.ServerAddress = c.HostName + ":" + c.RPCPort
+	if (c.HostName != "") && (c.RPCPort != "") {
+		c.Worker.ServerAddress = c.HostName + ":" + c.RPCPort
+	}
 	c.Worker.Storage = c.Storage
 	c.Worker.WorkDir = c.WorkDir
 	c.Worker.LogLevel = c.LogLevel
@@ -198,20 +200,20 @@ func WorkerInheritConfigVals(c Config) Worker {
 }
 
 // ToYaml formats the configuration into YAML and returns the bytes.
-func (c Worker) ToYaml() []byte {
+func (c Config) ToYaml() []byte {
 	// TODO handle error
 	yamlstr, _ := yaml.Marshal(c)
 	return yamlstr
 }
 
 // ToYamlFile writes the configuration to a YAML file.
-func (c Worker) ToYamlFile(p string) {
+func (c Config) ToYamlFile(p string) {
 	// TODO handle error
 	ioutil.WriteFile(p, c.ToYaml(), 0600)
 }
 
 // ToYamlTempFile writes the configuration to a YAML temp. file.
-func (c Worker) ToYamlTempFile(name string) (string, func()) {
+func (c Config) ToYamlTempFile(name string) (string, func()) {
 	// I'm creating a temp. directory instead of a temp. file so that
 	// the file can have an expected name. This is helpful for the HTCondor scheduler.
 	tmpdir, _ := ioutil.TempDir("", "")

--- a/src/funnel/scheduler/condor/sched.go
+++ b/src/funnel/scheduler/condor/sched.go
@@ -83,15 +83,15 @@ func (s *scheduler) StartWorker(w *pbf.Worker) error {
 		return err
 	}
 
-	c := s.conf.Worker
-	c.ID = w.Id
-	c.Timeout = 5 * time.Second
-	c.Resources.Cpus = w.Resources.Cpus
-	c.Resources.Ram = w.Resources.Ram
-	c.Resources.Disk = w.Resources.Disk
+	wc := s.conf
+	wc.Worker.ID = w.Id
+	wc.Worker.Timeout = 5 * time.Second
+	wc.Worker.Resources.Cpus = w.Resources.Cpus
+	wc.Worker.Resources.Ram = w.Resources.Ram
+	wc.Worker.Resources.Disk = w.Resources.Disk
 
 	confPath := path.Join(workdir, "worker.conf.yml")
-	c.ToYamlFile(confPath)
+	wc.ToYamlFile(confPath)
 
 	workerPath := sched.DetectWorkerPath()
 
@@ -149,14 +149,14 @@ queue
 func resolveCondorResourceRequest(cpus int, ram float64, disk float64) string {
 	var resources = []string{}
 	if cpus != 0 {
-		resources = append(resources, fmt.Sprintf("request_cpus = %d", cpus))
+		resources = append(resources, fmt.Sprintf("request_cpus   = %d", cpus))
 	}
 	if ram != 0.0 {
 		resources = append(resources, fmt.Sprintf("request_memory = %f GB", ram))
 	}
 	if disk != 0.0 {
 		// Convert GB to KiB
-		resources = append(resources, fmt.Sprintf("request_disk = %f", disk*976562))
+		resources = append(resources, fmt.Sprintf("request_disk   = %f", disk*976562))
 	}
 	return strings.Join(resources, "\n")
 }

--- a/src/funnel/scheduler/gce/client.go
+++ b/src/funnel/scheduler/gce/client.go
@@ -15,7 +15,7 @@ import (
 // or start a worker instance.
 type Client interface {
 	Templates() []pbf.Worker
-	StartWorker(tplName string, conf config.Worker) error
+	StartWorker(tplName string, conf config.Config) error
 }
 
 // Helper for creating a wrapper before creating a client
@@ -92,7 +92,7 @@ func (s *gceClient) Templates() []pbf.Worker {
 
 // StartWorker calls out to GCE APIs to create a VM instance
 // with a Funnel worker.
-func (s *gceClient) StartWorker(tplName string, conf config.Worker) error {
+func (s *gceClient) StartWorker(tplName string, conf config.Config) error {
 	s.loadTemplates()
 
 	// Get the instance template from the GCE API
@@ -124,7 +124,7 @@ func (s *gceClient) StartWorker(tplName string, conf config.Worker) error {
 
 	// Create the instance on GCE
 	instance := compute.Instance{
-		Name:              conf.ID,
+		Name:              conf.Worker.ID,
 		CanIpForward:      props.CanIpForward,
 		Description:       props.Description,
 		Disks:             props.Disks,

--- a/src/funnel/scheduler/gce/mocks/Client.go
+++ b/src/funnel/scheduler/gce/mocks/Client.go
@@ -11,11 +11,11 @@ type Client struct {
 }
 
 // StartWorker provides a mock function with given fields: tplName, conf
-func (_m *Client) StartWorker(tplName string, conf config.Worker) error {
+func (_m *Client) StartWorker(tplName string, conf config.Config) error {
 	ret := _m.Called(tplName, conf)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, config.Worker) error); ok {
+	if rf, ok := ret.Get(0).(func(string, config.Config) error); ok {
 		r0 = rf(tplName, conf)
 	} else {
 		r0 = ret.Error(0)

--- a/src/funnel/scheduler/gce/sched.go
+++ b/src/funnel/scheduler/gce/sched.go
@@ -128,9 +128,9 @@ func (s *gceScheduler) ShouldStartWorker(w *pbf.Worker) bool {
 func (s *gceScheduler) StartWorker(w *pbf.Worker) error {
 
 	// Write the funnel worker config yaml to a string
-	c := s.conf.Worker
-	c.ID = w.Id
-	c.Timeout = -1
+	wc := s.conf
+	wc.Worker.ID = w.Id
+	wc.Worker.Timeout = -1
 
 	// Get the template ID from the worker metadata
 	template, ok := w.Metadata["gce-template"]
@@ -138,5 +138,5 @@ func (s *gceScheduler) StartWorker(w *pbf.Worker) error {
 		return fmt.Errorf("Could not get GCE template ID from metadata")
 	}
 
-	return s.gce.StartWorker(template, c)
+	return s.gce.StartWorker(template, wc)
 }

--- a/src/funnel/scheduler/gce/sched_test.go
+++ b/src/funnel/scheduler/gce/sched_test.go
@@ -124,10 +124,10 @@ func TestSchedStartWorker(t *testing.T) {
 	log.Debug("Workers", workers)
 
 	// Expected worker config
-	wconf := conf.Worker
+	wconf := conf
 	// Expect ServerAddress to match the server's config
-	wconf.ServerAddress = conf.HostName + ":" + conf.RPCPort
-	wconf.ID = expected.Id
+	wconf.Worker.ServerAddress = conf.HostName + ":" + conf.RPCPort
+	wconf.Worker.ID = expected.Id
 	gce.On("StartWorker", "test-tpl", wconf).Return(nil)
 
 	scheduler.Scale(srv.DB, s)
@@ -312,8 +312,8 @@ func TestSchedMultipleJobsResourceUpdateBug(t *testing.T) {
 	gce.
 		On("StartWorker", "test-tpl", mock.Anything).
 		Run(func(args mock.Arguments) {
-			wconf := args[1].(config.Worker)
-			w = newMockWorker(wconf)
+			wconf := args[1].(config.Config)
+			w = newMockWorker(wconf.Worker)
 		}).
 		Return(nil)
 

--- a/src/funnel/scheduler/gce/wrapper_test.go
+++ b/src/funnel/scheduler/gce/wrapper_test.go
@@ -57,10 +57,10 @@ func TestWrapper(t *testing.T) {
 		t.Error("Worker has incorrect template")
 	}
 
-	workerConf := conf.Worker
-	workerConf.ID = w.Id
-	workerConf.ServerAddress = conf.HostName + ":" + conf.RPCPort
-	confYaml := string(workerConf.ToYaml())
+	wconf := conf
+	wconf.Worker.ID = w.Id
+	wconf.Worker.ServerAddress = conf.HostName + ":" + conf.RPCPort
+	confYaml := string(wconf.ToYaml())
 	expected := &Instance{
 		// TODO test that these fields get passed through from the template correctly.
 		//      i.e. mock a more complex template
@@ -99,8 +99,8 @@ func TestWrapper(t *testing.T) {
 // Tests what happens when the InsertInstance() call fails the first couple times.
 func TestInsertTempError(t *testing.T) {
 
-	conf := basicConf().Worker
-	conf.ID = "test-worker"
+	conf := basicConf()
+	conf.Worker.ID = "test-worker"
 	wpr := new(gce_mocks.Wrapper)
 	wpr.SetupMockInstanceTemplates()
 	wpr.SetupMockMachineTypes()

--- a/src/funnel/scheduler/openstack/scaler.go
+++ b/src/funnel/scheduler/openstack/scaler.go
@@ -37,8 +37,8 @@ func (s *scheduler) StartWorker(w *pbf.Worker) error {
 		return cerr
 	}
 
-	conf := s.conf.Worker
-	conf.ID = w.Id
+	conf := s.conf
+	conf.Worker.ID = w.Id
 	osconf := s.conf.Schedulers.OpenStack
 
 	_, serr := servers.Create(client, keypairs.CreateOptsExt{


### PR DESCRIPTION
Since I modified the CLI to read in a full config file these changes were needed.  In the past the worker CLI command expected that the YAML file only contained Worker config. 