### PR TITLE
Fix bug with worker config merging

### DIFF
--- a/src/funnel/cmd/worker.go
+++ b/src/funnel/cmd/worker.go
@@ -19,22 +19,21 @@ var workerCmd = &cobra.Command{
 	Use:   "worker",
 	Short: "",
 	Run: func(cmd *cobra.Command, args []string) {
-		var wconf = config.WorkerDefaultConfig(config.DefaultConfig())
-		var conf config.Config
+		conf := config.DefaultConfig()
+
 		if workerConfigFile != "" {
 			config.LoadConfigOrExit(workerConfigFile, &conf)
-			wconf = conf.Worker
 		}
 
 		workerDconf := config.WorkerInheritConfigVals(workerBaseConf)
 
 		// file vals <- cli val
-		err := mergo.MergeWithOverwrite(&wconf, workerDconf)
+		err := mergo.MergeWithOverwrite(&conf.Worker, workerDconf)
 		if err != nil {
 			panic(err)
 		}
 
-		startWorker(wconf)
+		startWorker(conf.Worker)
 	},
 }
 

--- a/src/funnel/config/config.go
+++ b/src/funnel/config/config.go
@@ -137,8 +137,22 @@ func DefaultConfig() Config {
 		ScheduleChunk:     10,
 		WorkerPingTimeout: time.Minute,
 		WorkerInitTimeout: time.Minute * 5,
+		Worker: Worker{
+			ServerAddress: hostName + ":" + rpcPort,
+			WorkDir:       workDir,
+			Timeout:       -1,
+			// TODO these get reset to zero when not found in yaml?
+			UpdateRate:    time.Second * 5,
+			LogUpdateRate: time.Second * 5,
+			TrackerRate:   time.Second * 5,
+			LogTailSize:   10000,
+			LogLevel:      "debug",
+			UpdateTimeout: time.Second,
+			Resources: &pbf.Resources{
+				Disk: 100.0,
+			},
+		},
 	}
-	c.Worker = WorkerDefaultConfig(c)
 	return c
 }
 
@@ -166,26 +180,6 @@ type Worker struct {
 	// Timeout duration for UpdateWorker() and UpdateJobLogs() RPC calls
 	UpdateTimeout time.Duration
 	Metadata      map[string]string
-}
-
-// WorkerDefaultConfig returns simple, default worker configuration.
-func WorkerDefaultConfig(c Config) Worker {
-	return Worker{
-		ServerAddress: c.HostName + ":" + c.RPCPort,
-		WorkDir:       c.WorkDir,
-		Timeout:       -1,
-		// TODO these get reset to zero when not found in yaml?
-		UpdateRate:    time.Second * 5,
-		LogUpdateRate: time.Second * 5,
-		TrackerRate:   time.Second * 5,
-		LogTailSize:   10000,
-		Storage:       c.Storage,
-		LogLevel:      "debug",
-		UpdateTimeout: time.Second,
-		Resources: &pbf.Resources{
-			Disk: 100.0,
-		},
-	}
 }
 
 // WorkerInheritConfigVals is a utility to help ensure the Worker inherits the proper config values from the parent Config

--- a/src/funnel/worker/worker_test.go
+++ b/src/funnel/worker/worker_test.go
@@ -119,7 +119,7 @@ func TestJobFail(t *testing.T) {
 // error from client.GetWorker().
 func TestGetWorkerFail(t *testing.T) {
 	// Create worker
-	conf := config.WorkerDefaultConfig(config.DefaultConfig())
+	conf := config.DefaultConfig().Worker
 	w, err := NewWorker(conf)
 	if err != nil {
 		t.Error(err)
@@ -174,7 +174,7 @@ func TestWorkerTimeout(t *testing.T) {
 
 // Test calling Worker.Stop()
 func TestStopWorker(t *testing.T) {
-	w, _ := NewWorker(config.WorkerDefaultConfig(config.DefaultConfig()))
+	w, _ := NewWorker(config.DefaultConfig().Worker)
 	done := make(chan struct{})
 	go func() {
 		w.Run()


### PR DESCRIPTION
Fixes an panic such as 
```
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: panic: non-positive interval for NewTicker
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: goroutine 1 [running]:
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: time.NewTicker(0x0, 0xd0256e)
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: #011/usr/local/Cellar/go/1.8/libexec/src/time/tick.go:23 +0x1b4
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: funnel/worker.(*Worker).Run(0xc420199100)
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: #011/Users/buchanae/projects/funnel/src/funnel/worker/worker.go:58 +0xa1
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: funnel/cmd.startWorker(0xc42029cbc0, 0x32, 0xc42032e4e0, 0x12, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
Apr 11 19:08:47 funnel-worker start-funnel.sh[1570]: #011/Users/buchanae/projects/funnel/src/funnel/cmd/worker.go:79 +0x2ef
```

which was caused by incorrect merging of configurations 