### PR TITLE
Local storage path encoding fix

### DIFF
--- a/storage/gs.go
+++ b/storage/gs.go
@@ -151,7 +151,7 @@ func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, cl
 				if err != nil {
 					return err
 				}
-				return gs.Put(ctx, filepath.Join(rawurl, rel), p, File)
+				return gs.Put(ctx, rawurl+"/"+rel, p, File)
 			}
 			return nil
 		})

--- a/storage/gs.go
+++ b/storage/gs.go
@@ -147,9 +147,11 @@ func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, cl
 	} else if class == Directory {
 		err := filepath.Walk(hostPath, func(p string, f os.FileInfo, err error) error {
 			if !f.IsDir() {
-				rel, _ := filepath.Rel(hostPath, p)
-				gs.Put(ctx, rawurl+"/"+rel, p, File)
-				log.Debug("Subpath", "full", p, "rel", rel)
+				rel, err := filepath.Rel(hostPath, p)
+				if err != nil {
+					return err
+				}
+				return gs.Put(ctx, filepath.Join(rawurl, rel), p, File)
 			}
 			return nil
 		})

--- a/storage/local.go
+++ b/storage/local.go
@@ -41,13 +41,13 @@ func (local *LocalBackend) Get(ctx context.Context, url string, hostPath string,
 	if class == File {
 		err = linkFile(path, hostPath)
 	} else if class == Directory {
-		err = filepath.Walk(hostPath, func(p string, f os.FileInfo, err error) error {
+		err = filepath.Walk(path, func(p string, f os.FileInfo, err error) error {
 			if !f.IsDir() {
-				rel, err := filepath.Rel(hostPath, p)
+				rel, err := filepath.Rel(path, p)
 				if err != nil {
 					return err
 				}
-				return local.Get(ctx, filepath.Join(url, rel), p, File)
+				return local.Get(ctx, p, filepath.Join(hostPath, rel), File)
 			}
 			return nil
 		})
@@ -85,7 +85,7 @@ func (local *LocalBackend) Put(ctx context.Context, url string, hostPath string,
 				if err != nil {
 					return err
 				}
-				return local.Put(ctx, filepath.Join(url, rel), p, File)
+				return local.Put(ctx, filepath.Join(path, rel), p, File)
 			}
 			return nil
 		})

--- a/storage/local.go
+++ b/storage/local.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
 	"io"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -48,7 +47,7 @@ func (local *LocalBackend) Get(ctx context.Context, url string, hostPath string,
 				if err != nil {
 					return err
 				}
-				return local.Put(ctx, filepath.Join(url, rel), p, File)
+				return local.Get(ctx, filepath.Join(url, rel), p, File)
 			}
 			return nil
 		})
@@ -107,21 +106,8 @@ func (local *LocalBackend) Supports(rawurl string, hostPath string, class tes.Fi
 }
 
 func getPath(rawurl string) (string, bool) {
-	u, err := url.Parse(rawurl)
-	if err != nil {
-		return "", false
-	}
-	if u.EscapedPath() == "" {
-		return "", false
-	}
-	if u.Scheme == "file" {
-		return u.EscapedPath(), true
-	}
-	// Handle URLs that are file paths, e.g. "/path/to/foo.txt"
-	if u.Scheme == "" && u.Host == "" {
-		return u.EscapedPath(), true
-	}
-	return "", false
+	p := strings.TrimPrefix(rawurl, "file://")
+	return p, strings.HasPrefix(p, "/")
 }
 
 func isAllowed(path string, allowedDirs []string) bool {

--- a/storage/local.go
+++ b/storage/local.go
@@ -119,7 +119,7 @@ func getPath(rawurl string) (string, bool) {
 	}
 	// Handle URLs that are file paths, e.g. "/path/to/foo.txt"
 	if u.Scheme == "" && u.Host == "" {
-		return u.Path, true
+		return u.EscapedPath(), true
 	}
 	return "", false
 }

--- a/storage/local.go
+++ b/storage/local.go
@@ -55,10 +55,11 @@ func (local *LocalBackend) Get(ctx context.Context, url string, hostPath string,
 		err = fmt.Errorf("Unknown file class: %s", class)
 	}
 
-	if err == nil {
-		log.Info("Finished download", "url", url, "hostPath", hostPath)
+	if err != nil {
+		return err
 	}
-	return err
+	log.Info("Finished download", "url", url, "hostPath", hostPath)
+	return nil
 }
 
 // Put copies a file from the hostPath into storage.
@@ -92,9 +93,10 @@ func (local *LocalBackend) Put(ctx context.Context, url string, hostPath string,
 		return fmt.Errorf("Unknown file class: %s", class)
 	}
 
-	if err == nil {
-		log.Info("Finished upload", "url", url, "hostPath", hostPath)
+	if err != nil {
+		return err
 	}
+	log.Info("Finished upload", "url", url, "hostPath", hostPath)
 	return nil
 }
 

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -189,3 +189,17 @@ func TestSameFile(t *testing.T) {
 		t.Fatal("Unexpected content")
 	}
 }
+
+func TestGetPath(t *testing.T) {
+	x := "file:///foo/bar/file with spaces.txt"
+	e, ok := getPath(x)
+	if !ok || e != "/foo/bar/file with spaces.txt" {
+		t.Fatal("Unexpected URL encoding")
+	}
+
+	x = "/foo/bar/escaped%20with%20.txt"
+	e, ok = getPath(x)
+	if !ok || e != "/foo/bar/escaped%20with%20.txt" {
+		t.Fatal("Unexpected URL encoding")
+	}
+}


### PR DESCRIPTION
Encountered some inconsistent behavior that this PR addresses.  Essentially, URLs were being decoded in Get and Put, but not for the contents being recursively copied from a directory. 