### PR TITLE
cloud-init + google COS image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ website-dev:
 # Build docker image.
 docker: cross-compile
 	mkdir -p build/docker
-	cp build/bin/funnel-linux-amd64 build/docker/
+	cp build/bin/funnel-linux-amd64 build/docker/funnel
 	cp docker/* build/docker/
 	cd build/docker/ && docker build -t funnel .
 

--- a/cmd/gce/gce.go
+++ b/cmd/gce/gce.go
@@ -131,7 +131,6 @@ type metadata struct {
 		Zone       string
 		Attributes struct {
 			FunnelConfig              string `json:"funnel-config"`
-			FunnelWorker              string `json:"funnel-worker"`
 			FunnelWorkerServerAddress string `json:"funnel-worker-serveraddress"`
 		}
 	}

--- a/deployments/gce-cos/README.md
+++ b/deployments/gce-cos/README.md
@@ -1,0 +1,28 @@
+# Google Cloud Compute Deployment (Container-optimized)
+
+This guide covers deploying Funnel to [Google Cloud Compute (GCE)][gce] using Docker containers and Google's [container-optimized OS][cos].
+
+Previously, deploying Funnel to GCE required building and maintaining VM images. This approach replaces those VM images with Docker containers, which makes building and deploying VMs quicker and easier.
+
+# Requirements
+
+- [gcloud SDK][gcloud]
+
+# Deployment
+
+Run:
+```
+# Deploy a Funnel server
+./make-server.sh
+
+# Deploy a Funnel worker
+./make-worker
+
+# Create Funnel instance templates, which enables Funnel
+# to automatically create workers.
+./make-worker-templates.sh
+```
+
+[gce]: https://cloud.google.com/compute/
+[cos]: https://cloud.google.com/container-optimized-os/docs/
+[gcloud]: https://cloud.google.com/sdk/gcloud/

--- a/deployments/gce-cos/cloud-init.yaml
+++ b/deployments/gce-cos/cloud-init.yaml
@@ -1,0 +1,42 @@
+#cloud-config
+
+users:
+- name: funnel
+  uid: 4949
+  groups: docker
+  system: true
+
+write_files:
+- path: /etc/systemd/system/funnel.service
+  permissions: 0644
+  owner: root
+  content: |
+    [Unit]
+    Description=Start a Funnel server
+
+    [Service]
+    Environment=DOCKER_GROUP_ID=412
+    ExecStart=/usr/bin/docker run --rm -u 4949 --group-add ${DOCKER_GROUP_ID} --name=funnel -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v /var/db/funnel:/opt/funnel/funnel-work-dir -w /opt/funnel -p 80:8000 -p 9090:9090 buchanae/funnel:latest gce start
+    ExecStop=/usr/bin/docker stop funnel
+    ExecStopPost=/usr/bin/docker rm funnel
+
+- path: /etc/systemd/system/iptables-funnel.service
+  permissions: 0644
+  owner: root
+  content: |
+    [Unit]
+    Description=Set up iptables rules for Funnel (port 80 and 9090)
+
+    [Service]
+    Type=oneshot
+    ExecStart=/sbin/iptables -A INPUT -p tcp --dport 80 -j ACCEPT
+    ExecStart=/sbin/iptables -A INPUT -p tcp --dport 9090 -j ACCEPT
+
+
+runcmd:
+- mkdir /var/db/funnel
+- chown funnel:funnel /var/db/funnel
+- usermod -aG docker funnel
+- systemctl daemon-reload
+- systemctl start funnel.service
+- systemctl start iptables-funnel.service

--- a/deployments/gce-cos/cloud-init.yaml
+++ b/deployments/gce-cos/cloud-init.yaml
@@ -16,7 +16,7 @@ write_files:
 
     [Service]
     Environment=DOCKER_GROUP_ID=412
-    ExecStart=/usr/bin/docker run --rm -u 4949 --group-add ${DOCKER_GROUP_ID} --name=funnel -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v /var/db/funnel:/opt/funnel/funnel-work-dir -w /opt/funnel -p 80:8000 -p 9090:9090 buchanae/funnel:latest gce start
+    ExecStart=/usr/bin/docker run --rm -u 4949 --group-add ${DOCKER_GROUP_ID} --name=funnel -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v /var/db/funnel:/opt/funnel/funnel-work-dir -w /opt/funnel -p 80:8000 -p 9090:9090 docker.io/ohsucompbio/funnel:latest gce start
     ExecStop=/usr/bin/docker stop funnel
     ExecStopPost=/usr/bin/docker rm funnel
 

--- a/deployments/gce-cos/make-server.sh
+++ b/deployments/gce-cos/make-server.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This creates a VM on GCE and deploys a Funnel server.
+
+NAME='funnel-server'
+
+# Ensure that a firewall rule exists allowing HTTP traffic
+gcloud compute firewall-rules create default-http --allow='tcp:80' --source-tags='http-server' --quiet
+
+# Start the VM
+gcloud compute instances create $NAME    \
+  --scopes       'compute-rw,storage-rw' \
+  --zone         'us-west1-a'            \
+  --tags         'funnel,http-server'    \
+  --machine-type n1-standard-2           \
+  --image-family cos-stable              \
+  --image-project cos-cloud              \
+  --metadata-from-file user-data=./cloud-init.yaml
+
+# Useful for debugging
+#gcloud compute instances add-metadata $NAME --metadata=serial-port-enable=1 --zone us-west1-a
+#gcloud compute instances tail-serial-port-output $NAME --zone us-west1-a

--- a/deployments/gce-cos/make-worker-templates.sh
+++ b/deployments/gce-cos/make-worker-templates.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# List of machine types to create templates for.
+# https://cloud.google.com/compute/docs/machine-types
+MACHINE_TYPES="
+n1-standard-1
+n1-standard-2
+n1-standard-4
+"
+
+for mt in $MACHINE_TYPES; do
+  gcloud compute instance-templates create "funnel-worker-$mt" \
+    --scopes compute-rw,storage-rw \
+    --tags funnel \
+    --image-family funnel \
+    --machine-type $mt \
+    --boot-disk-type 'pd-standard' \
+    --boot-disk-size '250GB'
+done

--- a/deployments/gce-cos/make-worker.sh
+++ b/deployments/gce-cos/make-worker.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This creates a VM on GCE and deploys a Funnel worker.
+#
+# This expects a Funnel server to already be running.
+
+NAME="funnel-worker-$(date +%s)"
+FUNNEL_SERVER='funnel-server:9090'
+
+gcloud compute instances create $NAME                        \
+  --scopes compute-rw,storage-rw                             \
+  --zone 'us-west1-a'                                        \
+  --tags funnel                                              \
+  --image-family cos-stable                                  \
+  --image-project cos-cloud                                  \
+  --machine-type 'n1-standard-4'                             \
+  --boot-disk-type 'pd-standard'                             \
+  --boot-disk-size '250GB'                                   \
+  --metadata "funnel-worker-serveraddress=$FUNNEL_SERVER"    \
+  --metadata-from-file user-data=./cloud-init.yaml
+
+# Tail serial port logs.
+# Useful for debugging.
+#gcloud compute instances add-metadata $NAME --metadata=serial-port-enable=1
+#gcloud compute instances tail-serial-port-output $NAME

--- a/deployments/gce/README.md
+++ b/deployments/gce/README.md
@@ -1,0 +1,64 @@
+# Google Cloud Compute Deployment
+
+DEPRECATED: This guide uses VM images for deployment, but using Docker containers is much quicker and easier. See deployments/gce-cos.
+
+This guide covers deploying a Funnel server and workers to [Google Cloud Compute (GCE)][1].
+You'll need to create a Google Cloud project, and install the [gcloud][2] SDK.
+
+
+## Create a Funnel VM Image
+
+A Funnel [image][3] provides the basic dependencies and configuration
+needed by both Funnel servers and workers, and allows instances to start
+more quickly and reliably.
+
+Manually creating a GCE image can be tedious, but the Funnel [image installer][4]
+makes it a little easier and automated.
+
+Run:
+```
+bash ./make-image.sh
+```
+
+This takes a few minutes. The installer needs to create a VM instance,
+snapshot, disk, and then finally an image. Images will be created in the
+"funnel" [image family][imgfam].
+
+
+## Create a Server
+
+Now that you have an image, it's fairly easy to create a server.
+
+Run:
+```
+bash ./make-server.sh
+```
+
+
+<h2>Create a Worker <i class="optional">optional</i></h2>
+
+Create a worker;
+```bash
+bash ./make-worker.sh
+```
+
+
+<h2>Create Worker Templates <i class="optional">optional</i></h2>
+
+Funnel includes a GCE autoscaler which can automatically start workers as needed.
+Funnel uses [instances templates][8] to describe the types of workers available.
+
+The script below creates three templates for workers of various sizes:
+1 CPU, 2 CPU, and 4 CPU.
+
+```bash
+bash ./make-worker-templates.sh
+```
+
+
+[1]: https://cloud.google.com/compute/
+[2]: https://cloud.google.com/sdk/gcloud/
+[3]: https://cloud.google.com/compute/docs/images
+[4]: https://github.com/ohsu-comp-bio/funnel/tree/master/deployments/gce/bundle
+[8]: https://cloud.google.com/compute/docs/instance-templates
+[imgfam]: https://cloud.google.com/compute/docs/images#image_families


### PR DESCRIPTION
This simplifies deployment to Google by using their container-optimized OS (COS) and dockerized funnel. This removes the steps needed to build and deploy a Funnel VM image.

I'm leaving the existing VM-image deployment as is for now, in case it's actually useful to someone, some day. I'll revisit down the road to clean it up if it's not used.