### PR TITLE
Use TestMain instead of init

### DIFF
--- a/server/scheduler_service.go
+++ b/server/scheduler_service.go
@@ -361,7 +361,6 @@ func (taskBolt *TaskBolt) UpdateExecutorLogs(ctx context.Context, req *pbf.Updat
 			// Check if there is an existing task log
 			o := bL.Get(key)
 			if o != nil {
-				log.Debug("UPDTA")
 				// There is an existing log in the DB, load it
 				existing := &tes.ExecutorLog{}
 				// max bytes to be stored in the db

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -1,10 +1,19 @@
 package e2e
 
 import (
+	"github.com/ohsu-comp-bio/funnel/logger"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
+	"os"
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	logger.ForceColors()
+	fun.StartServer()
+	e := m.Run()
+	os.Exit(e)
+}
 
 func TestHelloWorld(t *testing.T) {
 	id := fun.Run(`

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -1,13 +1,19 @@
 package e2e
 
 import (
+	"github.com/ohsu-comp-bio/funnel/logger"
+	"github.com/ohsu-comp-bio/funnel/tests/e2e"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
 )
 
+var log = logger.New("e2e-s3")
+var fun = e2e.NewFunnel()
+
 func TestMain(m *testing.M) {
+	fun.StartServer()
 	// Start minio
 	dockerPath, _ := exec.LookPath("docker")
 	args := []string{dockerPath, "run",

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -26,11 +26,6 @@ import (
 var log = logger.New("e2e")
 var fun = NewFunnel()
 
-func init() {
-	logger.ForceColors()
-	fun.StartServer()
-}
-
 // Funnel provides a test server and RPC/HTTP clients
 type Funnel struct {
 	// Clients


### PR DESCRIPTION
This makes the e2e test server more reusable by moving the `init()` code to `TestMain()`. The S3 tests also had a TestMain, so that moved into a subpackage to remove that conflict. Also cleaned up an unwanted debug log line.