### PR TITLE
fixed bug in local storage backend

### DIFF
--- a/storage/local.go
+++ b/storage/local.go
@@ -181,12 +181,6 @@ func copyFile(source string, dest string) (err error) {
 	if err != nil {
 		return err
 	}
-	// ensure readable output files
-	_ = syscall.Umask(0000)
-	err = os.Chmod(dest, 0766)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -210,7 +204,7 @@ func linkFile(source string, dest string) error {
 	dstD := path.Dir(dest)
 	if _, err := os.Stat(dstD); err != nil {
 		_ = syscall.Umask(0000)
-		err = os.MkdirAll(dstD, 0777)
+		err = os.MkdirAll(dstD, 0775)
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/storage_test.go
+++ b/tests/e2e/storage_test.go
@@ -108,3 +108,27 @@ func TestSymlinkOutput(t *testing.T) {
 		t.Fatal("unexpected out-dir/sym content")
 	}
 }
+
+func TestOverwriteOutput(t *testing.T) {
+	id := fun.Run(`
+    --cmd "sh -c 'echo foo > $out; chmod go+w $out'"
+    -o out={{ .storage }}/test_out
+  `)
+	task := fun.Wait(id)
+
+	if task.State != tes.State_COMPLETE {
+		t.Fatal("expected success")
+	}
+
+	// this time around since the output file exists copyFile will be called
+	// in storage.Put
+	id = fun.Run(`
+    --cmd "sh -c 'echo foo > $out; chmod go+w $out'"
+    -o out={{ .storage }}/test_out
+  `)
+	task = fun.Wait(id)
+
+	if task.State != tes.State_COMPLETE {
+		t.Fatal("expected success")
+	}
+}

--- a/util/dir.go
+++ b/util/dir.go
@@ -27,7 +27,7 @@ func EnsureDir(p string) error {
 	if !e {
 		// TODO configurable mode?
 		_ = syscall.Umask(0000)
-		err := os.MkdirAll(p, 0777)
+		err := os.MkdirAll(p, 0775)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Submitting two tasks that write to the same output location results in a permission denied error in some cases. 

Example:

`funnel run 'sh -c "echo hello world > $OUT; chmod go+w $OUT"' -o OUT=./test_out --container alpine:latest`
