### PR TITLE
Fix GCE deploy scripts

### DIFF
--- a/deployments/gce-cos/cloud-init.yaml
+++ b/deployments/gce-cos/cloud-init.yaml
@@ -37,6 +37,7 @@ runcmd:
 - mkdir /var/db/funnel
 - chown funnel:funnel /var/db/funnel
 - usermod -aG docker funnel
+- docker pull docker.io/ohsucompbio/funnel:latest
 - systemctl daemon-reload
 - systemctl start funnel.service
 - systemctl start iptables-funnel.service

--- a/deployments/gce-cos/make-worker-templates.sh
+++ b/deployments/gce-cos/make-worker-templates.sh
@@ -10,10 +10,12 @@ n1-standard-4
 
 for mt in $MACHINE_TYPES; do
   gcloud compute instance-templates create "funnel-worker-$mt" \
-    --scopes compute-rw,storage-rw \
-    --tags funnel \
-    --image-family funnel \
-    --machine-type $mt \
-    --boot-disk-type 'pd-standard' \
-    --boot-disk-size '250GB'
+    --scopes compute-rw,storage-rw         \
+    --tags funnel                          \
+    --image-family cos-stable              \
+    --image-project cos-cloud              \
+    --machine-type $mt                     \
+    --boot-disk-type 'pd-standard'         \
+    --boot-disk-size '250GB'               \
+    --metadata-from-file user-data=./cloud-init.yaml
 done

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM docker:stable
 ADD funnel /opt/funnel/funnel
 VOLUME /opt/funnel/funnel-work-dir
 EXPOSE 8000 9090

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -30,6 +30,14 @@ type DockerCmd struct {
 
 // Run runs the Docker command and blocks until done.
 func (dcmd DockerCmd) Run() error {
+  // (Hopefully) temporary hack to sync docker API version info.
+  // Don't need the client here, just the logic inside NewDockerClient().
+  _, derr := util.NewDockerClient()
+	if derr != nil {
+    log.Error("Can't connect to Docker", derr)
+		return derr
+	}
+
 	args := []string{"run", "-i"}
 
 	if dcmd.RemoveContainer {

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -30,11 +30,11 @@ type DockerCmd struct {
 
 // Run runs the Docker command and blocks until done.
 func (dcmd DockerCmd) Run() error {
-  // (Hopefully) temporary hack to sync docker API version info.
-  // Don't need the client here, just the logic inside NewDockerClient().
-  _, derr := util.NewDockerClient()
+	// (Hopefully) temporary hack to sync docker API version info.
+	// Don't need the client here, just the logic inside NewDockerClient().
+	_, derr := util.NewDockerClient()
 	if derr != nil {
-    log.Error("Can't connect to Docker", derr)
+		log.Error("Can't connect to Docker", derr)
 		return derr
 	}
 


### PR DESCRIPTION
While testing the direct-to-task branch on GCE, a couple issues cropped up:

- the make-worker-templates.sh script was wrong
- the docker image is based on "docker:stable" in that branch, which creates issues with client/server API version mismatches in worker.DockerCmd.Run.

This fixes those. 


During testing, I also had intermittent issues with the VM failing to start because it couldn't get the funnel image from docker hub. I added a "docker pull" to the cloud-init.yaml file to try to mitigate that.


I'll need to update dockerhub when this is merged.