### PR TITLE
Add context to worker logging

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -148,6 +148,18 @@ func recoverLogErr() {
 	}
 }
 
+// TODO having this hard-coded into the logger is a hack.
+//      ideally, it's configured per-logger instance, but
+//      right now that would require a larger logger refactor.
+
+type contextKey string
+
+// TaskIDKey defines the context value key used to find the task ID.
+const TaskIDKey = contextKey("taskID")
+
+// WorkerIDKey defines the context value key used to find the worker ID.
+const WorkerIDKey = contextKey("workerID")
+
 // converts an argument list to a map, e.g.
 // ("key", value, "key2", value2) => {"key": value, "key2", value2}
 //
@@ -171,11 +183,11 @@ func fields(args ...interface{}) map[string]interface{} {
 		case error:
 			expanded = append(expanded, "error", a)
 		case context.Context:
-			if id, ok := x.Value("taskID").(string); ok {
-				expanded = append(expanded, "taskID", id)
+			if id, ok := x.Value(TaskIDKey).(string); ok {
+				expanded = append(expanded, string(TaskIDKey), id)
 			}
-			if id, ok := x.Value("workerID").(string); ok {
-				expanded = append(expanded, "workerID", id)
+			if id, ok := x.Value(WorkerIDKey).(string); ok {
+				expanded = append(expanded, string(WorkerIDKey), id)
 			}
 		default:
 			expanded = append(expanded, a)

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -1,0 +1,60 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestLog(t *testing.T) {
+	l := New("foons", "basearg", 1)
+	c := DefaultConfig()
+	c.JSONFormat.DisableTimestamp = true
+	l.Configure(c)
+
+	var b bytes.Buffer
+	l.SetOutput(&b)
+	l.Info("test")
+
+	expect := `{"basearg":1,"level":"info","msg":"test","ns":"foons"}` + "\n"
+	if b.String() != expect {
+		t.Fatal("unexpected log:", b.String())
+	}
+}
+
+func TestContextLog(t *testing.T) {
+	l := New("foons", "basearg", 1)
+	c := DefaultConfig()
+	c.JSONFormat.DisableTimestamp = true
+	l.Configure(c)
+
+	var b bytes.Buffer
+	l.SetOutput(&b)
+
+	ctx := context.WithValue(context.Background(), TaskIDKey, "task-1")
+	l.Info("test", ctx)
+
+	expect := `{"basearg":1,"level":"info","msg":"test","ns":"foons","taskID":"task-1"}` + "\n"
+	if b.String() != expect {
+		t.Fatal("unexpected log:", b.String())
+	}
+}
+
+func TestErrorFieldLog(t *testing.T) {
+	l := New("foons", "basearg", 1)
+	c := DefaultConfig()
+	c.JSONFormat.DisableTimestamp = true
+	l.Configure(c)
+
+	var b bytes.Buffer
+	l.SetOutput(&b)
+
+	err := errors.New("fooerr")
+	l.Info("test", err)
+
+	expect := `{"basearg":1,"error":"fooerr","level":"info","msg":"test","ns":"foons"}` + "\n"
+	if b.String() != expect {
+		t.Fatal("unexpected log:", b.String())
+	}
+}

--- a/storage/gs.go
+++ b/storage/gs.go
@@ -68,7 +68,7 @@ func NewGSBackend(conf config.GSStorage) (*GSBackend, error) {
 
 // Get copies an object from GS to the host path.
 func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, class tes.FileType) error {
-	log.Info("Starting download", "url", rawurl)
+	log.Info("Starting download", ctx, "url", rawurl)
 
 	url, perr := parse(rawurl)
 	if perr != nil {
@@ -81,7 +81,7 @@ func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, cl
 		if err != nil {
 			return err
 		}
-		log.Info("Finished file download", "url", rawurl, "hostPath", hostPath)
+		log.Info("Finished file download", ctx, "url", rawurl, "hostPath", hostPath)
 		return nil
 
 	} else if class == tes.FileType_DIRECTORY {
@@ -94,7 +94,7 @@ func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, cl
 				return err
 			}
 		}
-		log.Info("Finished directory download", "url", rawurl, "hostPath", hostPath)
+		log.Info("Finished directory download", ctx, "url", rawurl, "hostPath", hostPath)
 		return nil
 	}
 	return fmt.Errorf("Unknown file class: %s", class)
@@ -121,7 +121,7 @@ func download(call *storage.ObjectsGetCall, hostPath string) error {
 
 // Put copies an object (file) from the host path to GS.
 func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
-	log.Info("Starting upload", "url", rawurl)
+	log.Info("Starting upload", ctx, "url", rawurl)
 
 	var out []*tes.OutputFileLog
 
@@ -161,7 +161,7 @@ func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, cl
 		return nil, fmt.Errorf("Unknown file class: %s", class)
 	}
 
-	log.Info("Finished upload", "url", rawurl, "hostPath", hostPath)
+	log.Info("Finished upload", ctx, "url", rawurl, "hostPath", hostPath)
 	return out, nil
 }
 

--- a/storage/local.go
+++ b/storage/local.go
@@ -34,7 +34,7 @@ func NewLocalBackend(conf config.LocalStorage) (*LocalBackend, error) {
 
 // Get copies a file from storage into the given hostPath.
 func (local *LocalBackend) Get(ctx context.Context, url string, hostPath string, class tes.FileType) error {
-	log.Info("Starting download", "url", url, "hostPath", hostPath)
+	log.Info("Starting download", ctx, "url", url, "hostPath", hostPath)
 	path, ok := getPath(url)
 
 	if !ok {
@@ -66,13 +66,13 @@ func (local *LocalBackend) Get(ctx context.Context, url string, hostPath string,
 	if err != nil {
 		return err
 	}
-	log.Info("Finished download", "url", url, "hostPath", hostPath)
+	log.Info("Finished download", ctx, "url", url, "hostPath", hostPath)
 	return nil
 }
 
 // Put copies a file from the hostPath into storage.
 func (local *LocalBackend) Put(ctx context.Context, url string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
-	log.Info("Starting upload", "url", url, "hostPath", hostPath)
+	log.Info("Starting upload", ctx, "url", url, "hostPath", hostPath)
 	path, ok := getPath(url)
 
 	if !ok {
@@ -123,7 +123,7 @@ func (local *LocalBackend) Put(ctx context.Context, url string, hostPath string,
 		return nil, err
 	}
 
-	log.Info("Finished upload", "url", url, "hostPath", hostPath)
+	log.Info("Finished upload", ctx, "url", url, "hostPath", hostPath)
 	return out, nil
 }
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -33,7 +33,7 @@ func NewS3Backend(conf config.S3Storage) (*S3Backend, error) {
 
 // Get copies an object from S3 to the host path.
 func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class tes.FileType) error {
-	log.Info("Starting download", "url", url)
+	log.Info("Starting download", ctx, "url", url)
 	path := strings.TrimPrefix(url, S3Protocol)
 	split := strings.SplitN(path, "/", 2)
 
@@ -42,7 +42,7 @@ func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class
 		if err != nil {
 			return err
 		}
-		log.Info("Successfully saved", "hostPath", hostPath)
+		log.Info("Successfully saved", ctx, "hostPath", hostPath)
 		return nil
 	} else if class == Directory {
 		return fmt.Errorf("S3 directories not yet supported")
@@ -53,7 +53,7 @@ func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class
 // Put copies an object (file) from the host path to S3.
 func (s3 *S3Backend) Put(ctx context.Context, url string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
 
-	log.Info("Starting upload", "url", url)
+	log.Info("Starting upload", ctx, "url", url)
 	path := strings.TrimPrefix(url, S3Protocol)
 	// TODO it's easy to create an error if this starts with a "/"
 	//      maybe just strip it?
@@ -65,7 +65,7 @@ func (s3 *S3Backend) Put(ctx context.Context, url string, hostPath string, class
 		if err != nil {
 			return nil, err
 		}
-		log.Info("Successfully uploaded", "hostPath", hostPath)
+		log.Info("Successfully uploaded", ctx, "hostPath", hostPath)
 		return []*tes.OutputFileLog{
 			{Url: url, Path: hostPath, SizeBytes: fileSize(hostPath)},
 		}, nil

--- a/worker/step.go
+++ b/worker/step.go
@@ -41,7 +41,7 @@ func (s *stepRunner) Run(ctx context.Context) error {
 	defer ticker.Stop()
 
 	go func() {
-		done <- s.Cmd.Run()
+		done <- s.Cmd.Run(subctx)
 	}()
 	go s.inspectContainer(subctx)
 
@@ -49,7 +49,7 @@ func (s *stepRunner) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			// Likely the task was canceled.
-			s.Cmd.Stop()
+			s.Cmd.Stop(subctx)
 			s.TaskLogger.ExecutorEndTime(s.Num, time.Now())
 			return ctx.Err()
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -122,8 +122,8 @@ func (w *Worker) sync(ctx context.Context) {
 		if w.runners.Add(id) {
 			go func(id string) {
 				r := w.newRunner(w.conf, id)
-				rctx := context.WithValue(ctx, "workerID", w.conf.ID)
-				rctx = context.WithValue(rctx, "taskID", id)
+				rctx := context.WithValue(ctx, logger.WorkerIDKey, w.conf.ID)
+				rctx = context.WithValue(rctx, logger.TaskIDKey, id)
 				r.Run(rctx)
 				w.runners.Remove(id)
 			}(id)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -122,7 +122,9 @@ func (w *Worker) sync(ctx context.Context) {
 		if w.runners.Add(id) {
 			go func(id string) {
 				r := w.newRunner(w.conf, id)
-				r.Run(ctx)
+				rctx := context.WithValue(ctx, "workerID", w.conf.ID)
+				rctx = context.WithValue(rctx, "taskID", id)
+				r.Run(rctx)
 				w.runners.Remove(id)
 			}(id)
 		}


### PR DESCRIPTION
This adds handling of context values in logging arguments, and adds contexts to log calls in the worker and storage. This helps ensure that values such as taskID and workerID are included in log calls from components such as DockerCmd.