### PR TITLE
Axe the global logger in the worker package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/ghodss/yaml"
 	"github.com/ohsu-comp-bio/funnel/logger"
 	os_servers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
@@ -308,15 +309,13 @@ func ParseFile(relpath string, conf *Config) error {
 	// Read file
 	source, err := ioutil.ReadFile(path)
 	if err != nil {
-		logger.Error("Failure reading config", "path", path, "error", err)
-		return err
+		return fmt.Errorf("can't read config: %s", err)
 	}
 
 	// Parse file
 	perr := Parse(source, conf)
 	if perr != nil {
-		logger.Error("Failure reading config", "path", path, "error", perr)
-		return perr
+		return fmt.Errorf("can't read config: %s", perr)
 	}
 	return nil
 }

--- a/scheduler/node.go
+++ b/scheduler/node.go
@@ -27,7 +27,11 @@ func NewNode(conf config.Config) (*Node, error) {
 	}
 
 	// Detect available resources at startup
-	res := detectResources(conf.Scheduler.Node)
+	res, rerr := detectResources(conf.Scheduler.Node)
+	if rerr != nil {
+		log.Error("Error detecting resources", rerr)
+	}
+
 	timeout := util.NewIdleTimeout(conf.Scheduler.Node.Timeout)
 	state := pbs.NodeState_UNINITIALIZED
 
@@ -114,9 +118,9 @@ func (n *Node) checkConnection(ctx context.Context) {
 	// If its a 404 error create a new node
 	s, _ := status.FromError(err)
 	if s.Code() != codes.NotFound {
-		log.Error("Couldn't contact server.", err)
+		n.log.Error("Couldn't contact server.", err)
 	} else {
-		log.Info("Successfully connected to server.")
+		n.log.Info("Successfully connected to server.")
 	}
 }
 
@@ -134,10 +138,10 @@ func (n *Node) sync(ctx context.Context) {
 		// If its a 404 error create a new node
 		s, _ := status.FromError(err)
 		if s.Code() != codes.NotFound {
-			log.Error("Couldn't get node state during sync.", err)
+			n.log.Error("Couldn't get node state during sync.", err)
 			return
 		}
-		log.Info("Starting initial node sync", "nodeID", n.conf.ID)
+		n.log.Info("Starting initial node sync")
 		r = &pbs.Node{Id: n.conf.ID}
 	}
 
@@ -155,7 +159,11 @@ func (n *Node) sync(ctx context.Context) {
 	}
 
 	// Node data has been updated. Send back to server for database update.
-	res := detectResources(n.conf)
+	res, rerr := detectResources(n.conf)
+	if rerr != nil {
+		n.log.Error("Error detecting resources", rerr)
+	}
+
 	r.Resources = &pbs.Resources{
 		Cpus:   res.Cpus,
 		RamGb:  res.RamGb,
@@ -173,7 +181,7 @@ func (n *Node) sync(ctx context.Context) {
 
 	_, err = n.client.UpdateNode(context.Background(), r)
 	if err != nil {
-		log.Error("Couldn't save node update. Recovering.", err)
+		n.log.Error("Couldn't save node update. Recovering.", err)
 	}
 }
 

--- a/scheduler/testutils_test.go
+++ b/scheduler/testutils_test.go
@@ -40,6 +40,7 @@ func newTestNode(conf config.Config) testNode {
 	conf.Scheduler.Node.WorkDir = workDir
 	conf.Worker.WorkDir = workDir
 
+	res, _ := detectResources(conf.Scheduler.Node)
 	// A mock scheduler client allows this code to fake/control the worker's
 	// communication with a scheduler service.
 	s := new(schedmock.Client)
@@ -48,7 +49,7 @@ func newTestNode(conf config.Config) testNode {
 		workerConf: conf.Worker,
 		client:     s,
 		log:        log,
-		resources:  detectResources(conf.Scheduler.Node),
+		resources:  res,
 		newWorker:  NoopWorkerFactory,
 		workers:    newRunSet(),
 		timeout:    util.NewIdleTimeout(conf.Scheduler.Node.Timeout),

--- a/storage/gs.go
+++ b/storage/gs.go
@@ -53,7 +53,6 @@ func NewGSBackend(conf config.GSStorage) (*GSBackend, error) {
 		if err == nil {
 			client = defClient
 		} else {
-			log.Error("Error connecting Google Storage client. Defaulting to anonymous.", err)
 			// No auth config could be found, so default to anonymous.
 		}
 	}
@@ -68,7 +67,6 @@ func NewGSBackend(conf config.GSStorage) (*GSBackend, error) {
 
 // Get copies an object from GS to the host path.
 func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, class tes.FileType) error {
-	log.Info("Starting download", "url", rawurl)
 
 	url, perr := parse(rawurl)
 	if perr != nil {
@@ -81,7 +79,6 @@ func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, cl
 		if err != nil {
 			return err
 		}
-		log.Info("Finished file download", "url", rawurl, "hostPath", hostPath)
 		return nil
 
 	} else if class == tes.FileType_DIRECTORY {
@@ -94,7 +91,6 @@ func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, cl
 				return err
 			}
 		}
-		log.Info("Finished directory download", "url", rawurl, "hostPath", hostPath)
 		return nil
 	}
 	return fmt.Errorf("Unknown file class: %s", class)
@@ -121,8 +117,6 @@ func download(call *storage.ObjectsGetCall, hostPath string) error {
 
 // Put copies an object (file) from the host path to GS.
 func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
-	log.Info("Starting upload", "url", rawurl)
-
 	var out []*tes.OutputFileLog
 
 	switch class {
@@ -161,7 +155,6 @@ func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, cl
 		return nil, fmt.Errorf("Unknown file class: %s", class)
 	}
 
-	log.Info("Finished upload", "url", rawurl, "hostPath", hostPath)
 	return out, nil
 }
 

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -197,7 +197,7 @@ func TestSameFile(t *testing.T) {
 	ioutil.WriteFile(cp, []byte("foo"), os.ModePerm)
 	ioutil.WriteFile(cp2, []byte("bar"), os.ModePerm)
 
-	err = linkFile(cp, op)
+	err = os.Link(cp, op)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/log.go
+++ b/storage/log.go
@@ -1,5 +1,0 @@
-package storage
-
-import "github.com/ohsu-comp-bio/funnel/logger"
-
-var log = logger.Sub("storage")

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -33,7 +33,6 @@ func NewS3Backend(conf config.S3Storage) (*S3Backend, error) {
 
 // Get copies an object from S3 to the host path.
 func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class tes.FileType) error {
-	log.Info("Starting download", "url", url)
 	path := strings.TrimPrefix(url, S3Protocol)
 	split := strings.SplitN(path, "/", 2)
 
@@ -42,7 +41,6 @@ func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class
 		if err != nil {
 			return err
 		}
-		log.Info("Successfully saved", "hostPath", hostPath)
 		return nil
 	} else if class == Directory {
 		return fmt.Errorf("S3 directories not yet supported")
@@ -53,7 +51,6 @@ func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class
 // Put copies an object (file) from the host path to S3.
 func (s3 *S3Backend) Put(ctx context.Context, url string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
 
-	log.Info("Starting upload", "url", url)
 	path := strings.TrimPrefix(url, S3Protocol)
 	// TODO it's easy to create an error if this starts with a "/"
 	//      maybe just strip it?
@@ -65,7 +62,6 @@ func (s3 *S3Backend) Put(ctx context.Context, url string, hostPath string, class
 		if err != nil {
 			return nil, err
 		}
-		log.Info("Successfully uploaded", "hostPath", hostPath)
 		return []*tes.OutputFileLog{
 			{Url: url, Path: hostPath, SizeBytes: fileSize(hostPath)},
 		}, nil

--- a/worker/file_mapper_test.go
+++ b/worker/file_mapper_test.go
@@ -130,10 +130,10 @@ func TestMapTask(t *testing.T) {
 	}
 
 	if diff := deep.Equal(f.Inputs, ei); diff != nil {
-		log.Debug("Expected", fmt.Sprintf("%+v", ei))
-		log.Debug("Actual", fmt.Sprintf("%+v", f.Inputs))
+		t.Log("Expected", fmt.Sprintf("%+v", ei))
+		t.Log("Actual", fmt.Sprintf("%+v", f.Inputs))
 		for _, d := range diff {
-			log.Debug("Diff", d)
+			t.Log("Diff", d)
 		}
 		t.Fatal("unexpected mapper inputs")
 	}
@@ -147,19 +147,19 @@ func TestMapTask(t *testing.T) {
 	}
 
 	if diff := deep.Equal(f.Outputs, eo); diff != nil {
-		log.Debug("Expected", fmt.Sprintf("%+v", eo))
-		log.Debug("Actual", fmt.Sprintf("%+v", f.Outputs))
+		t.Log("Expected", fmt.Sprintf("%+v", eo))
+		t.Log("Actual", fmt.Sprintf("%+v", f.Outputs))
 		for _, d := range diff {
-			log.Debug("Diff", d)
+			t.Log("Diff", d)
 		}
 		t.Fatal("unexpected mapper outputs")
 	}
 
 	if diff := deep.Equal(f.Volumes, ev); diff != nil {
-		log.Debug("Expected", fmt.Sprintf("%+v", ev))
-		log.Debug("Actual", fmt.Sprintf("%+v", f.Volumes))
+		t.Log("Expected", fmt.Sprintf("%+v", ev))
+		t.Log("Actual", fmt.Sprintf("%+v", f.Volumes))
 		for _, d := range diff {
-			log.Debug("Diff", d)
+			t.Log("Diff", d)
 		}
 		t.Fatal("unexpected mapper volumes")
 	}

--- a/worker/log.go
+++ b/worker/log.go
@@ -1,5 +1,0 @@
-package worker
-
-import "github.com/ohsu-comp-bio/funnel/logger"
-
-var log = logger.Sub("worker")

--- a/worker/rpc_task.go
+++ b/worker/rpc_task.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"github.com/ohsu-comp-bio/funnel/config"
+	"github.com/ohsu-comp-bio/funnel/logger"
 	tl "github.com/ohsu-comp-bio/funnel/proto/tasklogger"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
 	"github.com/ohsu-comp-bio/funnel/util"
@@ -17,14 +18,15 @@ type RPCTask struct {
 	client        *taskClient
 	taskID        string
 	updateTimeout time.Duration
+	log           logger.Logger
 }
 
-func newRPCTask(conf config.Worker, taskID string) (*RPCTask, error) {
+func newRPCTask(conf config.Worker, taskID string, log logger.Logger) (*RPCTask, error) {
 	client, err := newTaskClient(conf)
 	if err != nil {
 		return nil, err
 	}
-	return &RPCTask{client, taskID, conf.UpdateTimeout}, nil
+	return &RPCTask{client, taskID, conf.UpdateTimeout, log}, nil
 }
 
 // Task returns the task descriptor.
@@ -173,7 +175,7 @@ func (r *RPCTask) updateExecutorLogs(up *tl.UpdateExecutorLogsRequest) error {
 	ctx, cleanup := context.WithTimeout(context.Background(), r.updateTimeout)
 	_, err := r.client.UpdateExecutorLogs(ctx, up)
 	if err != nil {
-		log.Error("Couldn't update executor logs", err)
+		r.log.Error("Couldn't update executor logs", err)
 	}
 	cleanup()
 	return err
@@ -183,7 +185,7 @@ func (r *RPCTask) updateTaskLogs(up *tl.UpdateTaskLogsRequest) error {
 	ctx, cleanup := context.WithTimeout(context.Background(), r.updateTimeout)
 	_, err := r.client.UpdateTaskLogs(ctx, up)
 	if err != nil {
-		log.Error("Couldn't update task logs", err)
+		r.log.Error("Couldn't update task logs", err)
 	}
 	cleanup()
 	return err

--- a/worker/util.go
+++ b/worker/util.go
@@ -49,20 +49,23 @@ func externalIP() (string, error) {
 }
 
 // getExitCode gets the exit status (i.e. exit code) from the result of an executed command.
-// The exit code is zero if the command completed without error.
-func getExitCode(err error) int {
-	if err != nil {
-		if exiterr, exitOk := err.(*exec.ExitError); exitOk {
-			if status, statusOk := exiterr.Sys().(syscall.WaitStatus); statusOk {
-				return status.ExitStatus()
-			}
-		} else {
-			log.Info("Could not determine exit code. Using default -999", "err", err)
-			return -999
+func getExitCode(err error) (code int, ok bool) {
+	if err == nil {
+		// The error is nil, the command returned successfully, so exit status is 0.
+		ok = true
+		return
+	}
+
+	if exiterr, exitOk := err.(*exec.ExitError); exitOk {
+		if status, statusOk := exiterr.Sys().(syscall.WaitStatus); statusOk {
+			code = status.ExitStatus()
+			ok = true
+			return
 		}
 	}
-	// The error is nil, the command returned successfully, so exit status is 0.
-	return 0
+
+	// Could not determine exit status
+	return
 }
 
 // recover from panic and call "cb" with an error value.


### PR DESCRIPTION
Here's a prototype of what it might look like to start removing the global logger. This would make #194 obsolete.