### PR TITLE
FUNNEL_SERVER env var for CLI

### DIFF
--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -138,6 +138,7 @@ func defaultVals(vals *flagVals) {
 		vals.name = "Funnel run: " + vals.execs[0].cmd
 	}
 
+	vals.server = os.Getenv("FUNNEL_SERVER")
 	if vals.server == "" {
 		vals.server = "http://localhost:8000"
 	}

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -22,7 +22,7 @@ func init() {
 		tesServer = "http://localhost:8000"
 	}
 
-	Cmd.PersistentFlags().StringVarP(&tesServer, "server", "S", tesServer, "")
+	Cmd.PersistentFlags().StringVarP(&tesServer, "server", "S", tesServer, `may be set by FUNNEL_SERVER env var`)
 	Cmd.AddCommand(listCmd)
 	Cmd.AddCommand(createCmd)
 	Cmd.AddCommand(getCmd)

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -3,6 +3,7 @@ package task
 import (
 	"github.com/ohsu-comp-bio/funnel/logger"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var tesServer string
@@ -16,7 +17,12 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.PersistentFlags().StringVarP(&tesServer, "server", "S", "http://localhost:8000", "")
+	tesServer = os.Getenv("FUNNEL_SERVER")
+	if tesServer == "" {
+		tesServer = "http://localhost:8000"
+	}
+
+	Cmd.PersistentFlags().StringVarP(&tesServer, "server", "S", tesServer, "")
 	Cmd.AddCommand(listCmd)
 	Cmd.AddCommand(createCmd)
 	Cmd.AddCommand(getCmd)

--- a/cmd/version/data.go
+++ b/cmd/version/data.go
@@ -2,8 +2,8 @@ package version
 
 // Build and version details
 const (
-	GitCommit = "ef02e23"
-	GitBranch = "versioning"
-	BuildDate = "Fri Sep  8 13:21:21 PDT 2017"
-	Version   = "0.2.0-20-gef02e23-dirty"
+	GitCommit = "d52c856"
+	GitBranch = "user-conf"
+	BuildDate = "Sun Sep 10 12:23:23 PDT 2017"
+	Version   = "0.2.0-25-gd52c856-dirty"
 )

--- a/tests/e2e/sh/cancel_complete_task.sh
+++ b/tests/e2e/sh/cancel_complete_task.sh
@@ -1,0 +1,4 @@
+id=`funnel run 'echo hello'`
+funnel task wait $id
+funnel task cancel $id
+funnel task get --view MINIMAL $id

--- a/tests/e2e/sh/cancel_complete_task.sh.stderr
+++ b/tests/e2e/sh/cancel_complete_task.sh.stderr
@@ -1,0 +1,1 @@
+Error: [STATUS CODE - 500]	{"error":"Won't switch between two terminal states: COMPLETE -\u003e CANCELED","code":2}

--- a/tests/e2e/sh/cancel_complete_task.sh.stdout
+++ b/tests/e2e/sh/cancel_complete_task.sh.stdout
@@ -1,0 +1,3 @@
+{
+	"state": "COMPLETE"
+}

--- a/tests/e2e/sh/cancel_unknown.sh
+++ b/tests/e2e/sh/cancel_unknown.sh
@@ -1,0 +1,2 @@
+# Test canceling a task that doesn't exist
+funnel task cancel foo

--- a/tests/e2e/sh/cancel_unknown.sh.stderr
+++ b/tests/e2e/sh/cancel_unknown.sh.stderr
@@ -1,0 +1,1 @@
+Error: [STATUS CODE - 404]	{"error":"not found: taskID: foo","code":5}

--- a/tests/e2e/sh/hello.sh
+++ b/tests/e2e/sh/hello.sh
@@ -1,0 +1,3 @@
+id=`funnel run --cmd 'echo hello world'`
+funnel task wait $id
+funnel task get $id

--- a/tests/e2e/sh/hello.sh.stdout
+++ b/tests/e2e/sh/hello.sh.stdout
@@ -1,0 +1,29 @@
+{
+	"state": "COMPLETE",
+	"name": "Funnel run: echo hello world",
+	"resources": {
+
+	},
+	"executors": [
+		{
+			"imageName": "alpine",
+			"cmd": [
+				"echo",
+				"hello",
+				"world"
+			],
+			"workdir": "/opt/funnel",
+			"stdout": "/opt/funnel/outputs/stdout-0",
+			"stderr": "/opt/funnel/outputs/stderr-0"
+		}
+	],
+	"logs": [
+		{
+			"logs": [
+				{
+					"stdout": "hello world\n",
+				}
+			],
+		}
+	]
+}

--- a/tests/e2e/sh/minimal_view.sh
+++ b/tests/e2e/sh/minimal_view.sh
@@ -1,0 +1,3 @@
+id=`funnel run --cmd 'echo hello world' --name 'foo' --contents in=./testdata/hello.txt`
+funnel task wait $id
+funnel task get --view MINIMAL $id

--- a/tests/e2e/sh/minimal_view.sh.stdout
+++ b/tests/e2e/sh/minimal_view.sh.stdout
@@ -1,0 +1,3 @@
+{
+	"state": "COMPLETE"
+}

--- a/tests/e2e/sh/sh_test.go
+++ b/tests/e2e/sh/sh_test.go
@@ -1,0 +1,65 @@
+package sh
+
+import (
+	"bytes"
+	"github.com/ohsu-comp-bio/funnel/tests/e2e"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestScripts(t *testing.T) {
+
+	// Find all the test scripts.
+	// Start a subtest for each test script.
+	ps, _ := filepath.Glob("*.sh")
+	for _, p := range ps {
+		t.Run(p, func(t *testing.T) {
+
+			conf := e2e.DefaultConfig()
+			fun := e2e.NewFunnel(conf)
+			fun.WithLocalBackend()
+			fun.StartServer()
+
+			var stdout, stderr bytes.Buffer
+			cmd := exec.Command("/bin/sh", p)
+			cmd.Env = append(os.Environ(), "FUNNEL_SERVER="+conf.Server.HTTPAddress())
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			cmd.Run()
+
+			check(t, p+".stdout", stdout.Bytes())
+			check(t, p+".stderr", stderr.Bytes())
+		})
+	}
+}
+
+func check(t *testing.T, name string, result []byte) {
+	// Load the expected content from a file, if it exists and isn't empty.
+	if b, err := ioutil.ReadFile(name); err == nil && len(b) > 0 {
+		// Delete id, startTime, endTime, hostIp from task messages
+		// because they are non-deterministic
+		rx := regexp.MustCompile(`\s+"(id|startTime|endTime|hostIp)": ".*",?`)
+		result = rx.ReplaceAll(result, nil)
+
+		if !bytes.Equal(result, b) {
+			t.Error(name + " not matched")
+
+			dmp := diffmatchpatch.New()
+			d := dmp.DiffMain(string(result), string(b), true)
+			d = dmp.DiffCleanupSemantic(d)
+			d = dmp.DiffCleanupMerge(d)
+			d = dmp.DiffCleanupEfficiency(d)
+
+			t.Logf("diff\n%s", dmp.DiffPrettyText(d))
+			//t.Logf("result\n%s", string(result))
+			//t.Logf("expected\n%s", string(b))
+		}
+	} else if len(result) > 0 {
+		t.Errorf("missing expected output for %s. got result:\n%s", name, string(result))
+	}
+}

--- a/tests/e2e/sh/single_char_log.sh
+++ b/tests/e2e/sh/single_char_log.sh
@@ -1,0 +1,6 @@
+# Test that the streaming logs pick up a single character.
+# This ensures that the streaming works even when a small
+# amount of logs are written (which was once a bug).
+id=`funnel run 'echo a'`
+funnel task wait $id
+funnel task get --view FULL $id

--- a/tests/e2e/sh/single_char_log.sh.stdout
+++ b/tests/e2e/sh/single_char_log.sh.stdout
@@ -1,0 +1,28 @@
+{
+	"state": "COMPLETE",
+	"name": "Funnel run: echo a",
+	"resources": {
+
+	},
+	"executors": [
+		{
+			"imageName": "alpine",
+			"cmd": [
+				"echo",
+				"a"
+			],
+			"workdir": "/opt/funnel",
+			"stdout": "/opt/funnel/outputs/stdout-0",
+			"stderr": "/opt/funnel/outputs/stderr-0"
+		}
+	],
+	"logs": [
+		{
+			"logs": [
+				{
+					"stdout": "a\n",
+				}
+			],
+		}
+	]
+}

--- a/tests/e2e/sh/testdata/hello.txt
+++ b/tests/e2e/sh/testdata/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/tests/e2e/sh/unknown.sh
+++ b/tests/e2e/sh/unknown.sh
@@ -1,0 +1,1 @@
+funnel task get foo

--- a/tests/e2e/sh/unknown.sh.stderr
+++ b/tests/e2e/sh/unknown.sh.stderr
@@ -1,0 +1,1 @@
+Error: [STATUS CODE - 404]	{"error":"not found: taskID: foo","code":5}


### PR DESCRIPTION
This is my minimal effort, quick fix for avoiding writing `funnel -S http://some-funnel-server:8000` all the time.