### PR TITLE
task get/cancel/wait CLI commands read from stdin

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ohsu-comp-bio/funnel/cmd/server"
 	"github.com/ohsu-comp-bio/funnel/cmd/task"
 	"github.com/ohsu-comp-bio/funnel/cmd/termdash"
-	"github.com/ohsu-comp-bio/funnel/cmd/wait"
 	"github.com/ohsu-comp-bio/funnel/cmd/worker"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +27,5 @@ func init() {
 	RootCmd.AddCommand(server.Cmd)
 	RootCmd.AddCommand(task.Cmd)
 	RootCmd.AddCommand(termdash.Cmd)
-	RootCmd.AddCommand(wait.Cmd)
 	RootCmd.AddCommand(worker.Cmd)
 }

--- a/cmd/task/cancel.go
+++ b/cmd/task/cancel.go
@@ -11,37 +11,21 @@ var cancelCmd = &cobra.Command{
 	Use:   "cancel [taskID ...]",
 	Short: "cancel one or more tasks by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return cmd.Help()
-		}
-
-		res, err := doCancel(tesServer, args)
-		if err != nil {
-			return err
-		}
-
-		for _, x := range res {
-			fmt.Println(x)
-		}
-		return nil
+		return runPerID(cmd, args, doCancel)
 	},
 }
 
-func doCancel(server string, ids []string) ([]string, error) {
-	cli := client.NewClient(server)
-	res := []string{}
-
-	for _, taskID := range ids {
-		resp, err := cli.CancelTask(taskID)
-		if err != nil {
-			return nil, err
-		}
-		// CancelTaskResponse is an empty struct
-		out, err := cli.Marshaler.MarshalToString(resp)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, out)
+func doCancel(cli *client.Client, id string) error {
+	resp, err := cli.CancelTask(id)
+	if err != nil {
+		return err
 	}
-	return res, nil
+	// CancelTaskResponse is an empty struct
+	x, err := cli.Marshaler.MarshalToString(resp)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(x)
+	return nil
 }

--- a/cmd/task/get.go
+++ b/cmd/task/get.go
@@ -13,20 +13,7 @@ var getCmd = &cobra.Command{
 	Use:   "get [taskID ...]",
 	Short: "get one or more tasks by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return cmd.Help()
-		}
-
-		res, err := doGet(tesServer, args)
-		if err != nil {
-			return err
-		}
-
-		for _, x := range res {
-			fmt.Println(x)
-		}
-
-		return nil
+		return runPerID(cmd, args, doGet)
 	},
 }
 
@@ -34,20 +21,16 @@ func init() {
 	getCmd.Flags().StringVarP(&taskView, "view", "v", "FULL", "Task view")
 }
 
-func doGet(server string, ids []string) ([]string, error) {
-	cli := client.NewClient(server)
-	res := []string{}
-
-	for _, taskID := range ids {
-		resp, err := cli.GetTask(taskID, taskView)
-		if err != nil {
-			return nil, err
-		}
-		out, err := cli.Marshaler.MarshalToString(resp)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, out)
+func doGet(cli *client.Client, id string) error {
+	resp, err := cli.GetTask(id, taskView)
+	if err != nil {
+		return err
 	}
-	return res, nil
+	x, err := cli.Marshaler.MarshalToString(resp)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(x)
+	return nil
 }

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -56,17 +56,19 @@ func runPerID(cmd *cobra.Command, args []string, h perIDHandler) error {
 	}
 
 	// Read arguments from stdin
-	s := bufio.NewScanner(os.Stdin)
-	for s.Scan() {
-		arg := s.Text()
-		if err := h(cli, arg); err != nil {
+	if stdinPiped() {
+		s := bufio.NewScanner(os.Stdin)
+		for s.Scan() {
+			arg := s.Text()
+			if err := h(cli, arg); err != nil {
+				return err
+			}
+		}
+
+		// Check for scanner error
+		if err := s.Err(); err != nil {
 			return err
 		}
-	}
-
-	// Check for scanner error
-	if err := s.Err(); err != nil {
-		return err
 	}
 
 	return nil

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -21,4 +21,5 @@ func init() {
 	Cmd.AddCommand(createCmd)
 	Cmd.AddCommand(getCmd)
 	Cmd.AddCommand(cancelCmd)
+	Cmd.AddCommand(waitCmd)
 }

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -1,8 +1,11 @@
 package task
 
 import (
+	"bufio"
+	"github.com/ohsu-comp-bio/funnel/cmd/client"
 	"github.com/ohsu-comp-bio/funnel/logger"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var tesServer string
@@ -22,4 +25,49 @@ func init() {
 	Cmd.AddCommand(getCmd)
 	Cmd.AddCommand(cancelCmd)
 	Cmd.AddCommand(waitCmd)
+}
+
+// stdinPiped returns true if the cli command has stdin being piped,
+// e.g. 'echo $TASK_ID | funnel task get'
+func stdinPiped() bool {
+	stat, _ := os.Stdin.Stat()
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+type perIDHandler func(c *client.Client, id string) error
+
+// runPerID helps with commands that can accept task IDs via both CLI args
+// and stdin, such as `task get` and `task cancel`. The given handler func
+// is called once per task ID. Processing stops on the first error.
+func runPerID(cmd *cobra.Command, args []string, h perIDHandler) error {
+	// Arguments may be given either via the cli parser,
+	// or via stdin.
+	if len(args) == 0 && !stdinPiped() {
+		return cmd.Help()
+	}
+
+	cli := client.NewClient(tesServer)
+
+	// Read arguments from the cli parser
+	for _, arg := range args {
+		if err := h(cli, arg); err != nil {
+			return err
+		}
+	}
+
+	// Read arguments from stdin
+	s := bufio.NewScanner(os.Stdin)
+	for s.Scan() {
+		arg := s.Text()
+		if err := h(cli, arg); err != nil {
+			return err
+		}
+	}
+
+	// Check for scanner error
+	if err := s.Err(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/task/wait.go
+++ b/cmd/task/wait.go
@@ -1,14 +1,11 @@
-package wait
+package task
 
 import (
 	"github.com/ohsu-comp-bio/funnel/cmd/client"
 	"github.com/spf13/cobra"
 )
 
-var tesServer string
-
-// Cmd represents the run command
-var Cmd = &cobra.Command{
+var waitCmd = &cobra.Command{
 	Use:   "wait [taskID...]",
 	Short: "Wait for one or more tasks to complete.\n",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -24,8 +21,4 @@ var Cmd = &cobra.Command{
 		}
 		return nil
 	},
-}
-
-func init() {
-	Cmd.PersistentFlags().StringVarP(&tesServer, "server", "S", "http://localhost:8000", "")
 }

--- a/cmd/task/wait.go
+++ b/cmd/task/wait.go
@@ -9,16 +9,14 @@ var waitCmd = &cobra.Command{
 	Use:   "wait [taskID...]",
 	Short: "Wait for one or more tasks to complete.\n",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return cmd.Help()
-		}
-
-		cli := client.NewClient(tesServer)
-
-		err := cli.WaitForTask(args...)
-		if err != nil {
-			return err
-		}
-		return nil
+		return runPerID(cmd, args, doWait)
 	},
+}
+
+func doWait(cli *client.Client, id string) error {
+	err := cli.WaitForTask(id)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/config/bundle.go
+++ b/config/bundle.go
@@ -224,11 +224,11 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"config/default-config.yaml": configDefaultConfigYaml,
+	"config/default-config.yaml":     configDefaultConfigYaml,
 	"config/gridengine-template.txt": configGridengineTemplateTxt,
-	"config/htcondor-template.txt": configHtcondorTemplateTxt,
-	"config/pbs-template.txt": configPbsTemplateTxt,
-	"config/slurm-template.txt": configSlurmTemplateTxt,
+	"config/htcondor-template.txt":   configHtcondorTemplateTxt,
+	"config/pbs-template.txt":        configPbsTemplateTxt,
+	"config/slurm-template.txt":      configSlurmTemplateTxt,
 }
 
 // AssetDir returns the file names below a certain
@@ -270,13 +270,14 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"config": &bintree{nil, map[string]*bintree{
-		"default-config.yaml": &bintree{configDefaultConfigYaml, map[string]*bintree{}},
-		"gridengine-template.txt": &bintree{configGridengineTemplateTxt, map[string]*bintree{}},
-		"htcondor-template.txt": &bintree{configHtcondorTemplateTxt, map[string]*bintree{}},
-		"pbs-template.txt": &bintree{configPbsTemplateTxt, map[string]*bintree{}},
-		"slurm-template.txt": &bintree{configSlurmTemplateTxt, map[string]*bintree{}},
+	"config": {nil, map[string]*bintree{
+		"default-config.yaml":     {configDefaultConfigYaml, map[string]*bintree{}},
+		"gridengine-template.txt": {configGridengineTemplateTxt, map[string]*bintree{}},
+		"htcondor-template.txt":   {configHtcondorTemplateTxt, map[string]*bintree{}},
+		"pbs-template.txt":        {configPbsTemplateTxt, map[string]*bintree{}},
+		"slurm-template.txt":      {configSlurmTemplateTxt, map[string]*bintree{}},
 	}},
 }}
 
@@ -326,4 +327,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/examples/bundle.go
+++ b/examples/bundle.go
@@ -266,12 +266,12 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"examples/file-contents.json": examplesFileContentsJson,
-	"examples/google-storage.json": examplesGoogleStorageJson,
-	"examples/hello-world.json": examplesHelloWorldJson,
-	"examples/log-streaming.json": examplesLogStreamingJson,
-	"examples/md5sum.json": examplesMd5sumJson,
-	"examples/port-request.json": examplesPortRequestJson,
+	"examples/file-contents.json":    examplesFileContentsJson,
+	"examples/google-storage.json":   examplesGoogleStorageJson,
+	"examples/hello-world.json":      examplesHelloWorldJson,
+	"examples/log-streaming.json":    examplesLogStreamingJson,
+	"examples/md5sum.json":           examplesMd5sumJson,
+	"examples/port-request.json":     examplesPortRequestJson,
 	"examples/resource-request.json": examplesResourceRequestJson,
 }
 
@@ -314,15 +314,16 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"examples": &bintree{nil, map[string]*bintree{
-		"file-contents.json": &bintree{examplesFileContentsJson, map[string]*bintree{}},
-		"google-storage.json": &bintree{examplesGoogleStorageJson, map[string]*bintree{}},
-		"hello-world.json": &bintree{examplesHelloWorldJson, map[string]*bintree{}},
-		"log-streaming.json": &bintree{examplesLogStreamingJson, map[string]*bintree{}},
-		"md5sum.json": &bintree{examplesMd5sumJson, map[string]*bintree{}},
-		"port-request.json": &bintree{examplesPortRequestJson, map[string]*bintree{}},
-		"resource-request.json": &bintree{examplesResourceRequestJson, map[string]*bintree{}},
+	"examples": {nil, map[string]*bintree{
+		"file-contents.json":    {examplesFileContentsJson, map[string]*bintree{}},
+		"google-storage.json":   {examplesGoogleStorageJson, map[string]*bintree{}},
+		"hello-world.json":      {examplesHelloWorldJson, map[string]*bintree{}},
+		"log-streaming.json":    {examplesLogStreamingJson, map[string]*bintree{}},
+		"md5sum.json":           {examplesMd5sumJson, map[string]*bintree{}},
+		"port-request.json":     {examplesPortRequestJson, map[string]*bintree{}},
+		"resource-request.json": {examplesResourceRequestJson, map[string]*bintree{}},
 	}},
 }}
 
@@ -372,4 +373,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
Closes #204 

The following now work:
```
RJHB552 sh (204-task-cli-stdin)
funnel run --cmd 'sleep 10' | { sleep 1; cat; } | funnel task cancel
{

}

RJHB552 sh (204-task-cli-stdin)
funnel run --cmd 'sleep 10' | { sleep 3; cat; } | funnel task get
{
	"id": "b6mf3gqrl6qns29voncg",
	"state": "INITIALIZING",
	"name": "Funnel run: sleep 10",
	"resources": {

	},
	"executors": [
		{
			"imageName": "alpine",
			"cmd": [
				"sleep",
				"10"
			],
			"workdir": "/opt/funnel",
			"stdout": "/opt/funnel/outputs/stdout-0",
			"stderr": "/opt/funnel/outputs/stderr-0"
		}
	],
	"logs": [
		{

		}
	]
}

RJHB552 sh (204-task-cli-stdin)
funnel run --cmd 'sleep 10' | funnel task wait
```