### PR TITLE
Split TaskService into TaskReader + TaskWriter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/ghodss/yaml"
 	"github.com/ohsu-comp-bio/funnel/logger"
 	os_servers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
@@ -266,15 +267,13 @@ func ParseFile(relpath string, conf *Config) error {
 	// Read file
 	source, err := ioutil.ReadFile(path)
 	if err != nil {
-		logger.Error("Failure reading config", "path", path, "error", err)
-		return err
+		return fmt.Errorf("can't read config: %s", err)
 	}
 
 	// Parse file
 	perr := Parse(source, conf)
 	if perr != nil {
-		logger.Error("Failure reading config", "path", path, "error", perr)
-		return perr
+		return fmt.Errorf("can't read config: %s", perr)
 	}
 	return nil
 }

--- a/storage/gs.go
+++ b/storage/gs.go
@@ -53,7 +53,6 @@ func NewGSBackend(conf config.GSStorage) (*GSBackend, error) {
 		if err == nil {
 			client = defClient
 		} else {
-			log.Error("Error connecting Google Storage client. Defaulting to anonymous.", err)
 			// No auth config could be found, so default to anonymous.
 		}
 	}
@@ -68,7 +67,6 @@ func NewGSBackend(conf config.GSStorage) (*GSBackend, error) {
 
 // Get copies an object from GS to the host path.
 func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, class tes.FileType) error {
-	log.Info("Starting download", "url", rawurl)
 
 	url, perr := parse(rawurl)
 	if perr != nil {
@@ -81,7 +79,6 @@ func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, cl
 		if err != nil {
 			return err
 		}
-		log.Info("Finished file download", "url", rawurl, "hostPath", hostPath)
 		return nil
 
 	} else if class == tes.FileType_DIRECTORY {
@@ -94,7 +91,6 @@ func (gs *GSBackend) Get(ctx context.Context, rawurl string, hostPath string, cl
 				return err
 			}
 		}
-		log.Info("Finished directory download", "url", rawurl, "hostPath", hostPath)
 		return nil
 	}
 	return fmt.Errorf("Unknown file class: %s", class)
@@ -121,8 +117,6 @@ func download(call *storage.ObjectsGetCall, hostPath string) error {
 
 // Put copies an object (file) from the host path to GS.
 func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
-	log.Info("Starting upload", "url", rawurl)
-
 	var out []*tes.OutputFileLog
 
 	switch class {
@@ -161,7 +155,6 @@ func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, cl
 		return nil, fmt.Errorf("Unknown file class: %s", class)
 	}
 
-	log.Info("Finished upload", "url", rawurl, "hostPath", hostPath)
 	return out, nil
 }
 

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -197,7 +197,7 @@ func TestSameFile(t *testing.T) {
 	ioutil.WriteFile(cp, []byte("foo"), os.ModePerm)
 	ioutil.WriteFile(cp2, []byte("bar"), os.ModePerm)
 
-	err = linkFile(cp, op)
+	err = os.Link(cp, op)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/log.go
+++ b/storage/log.go
@@ -1,5 +1,0 @@
-package storage
-
-import "github.com/ohsu-comp-bio/funnel/logger"
-
-var log = logger.Sub("storage")

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -33,7 +33,6 @@ func NewS3Backend(conf config.S3Storage) (*S3Backend, error) {
 
 // Get copies an object from S3 to the host path.
 func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class tes.FileType) error {
-	log.Info("Starting download", "url", url)
 	path := strings.TrimPrefix(url, S3Protocol)
 	split := strings.SplitN(path, "/", 2)
 
@@ -42,7 +41,6 @@ func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class
 		if err != nil {
 			return err
 		}
-		log.Info("Successfully saved", "hostPath", hostPath)
 		return nil
 	} else if class == Directory {
 		return fmt.Errorf("S3 directories not yet supported")
@@ -53,7 +51,6 @@ func (s3 *S3Backend) Get(ctx context.Context, url string, hostPath string, class
 // Put copies an object (file) from the host path to S3.
 func (s3 *S3Backend) Put(ctx context.Context, url string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
 
-	log.Info("Starting upload", "url", url)
 	path := strings.TrimPrefix(url, S3Protocol)
 	// TODO it's easy to create an error if this starts with a "/"
 	//      maybe just strip it?
@@ -65,7 +62,6 @@ func (s3 *S3Backend) Put(ctx context.Context, url string, hostPath string, class
 		if err != nil {
 			return nil, err
 		}
-		log.Info("Successfully uploaded", "hostPath", hostPath)
 		return []*tes.OutputFileLog{
 			{Url: url, Path: hostPath, SizeBytes: fileSize(hostPath)},
 		}, nil

--- a/worker/file_mapper_test.go
+++ b/worker/file_mapper_test.go
@@ -130,10 +130,10 @@ func TestMapTask(t *testing.T) {
 	}
 
 	if diff := deep.Equal(f.Inputs, ei); diff != nil {
-		log.Debug("Expected", fmt.Sprintf("%+v", ei))
-		log.Debug("Actual", fmt.Sprintf("%+v", f.Inputs))
+		t.Log("Expected", fmt.Sprintf("%+v", ei))
+		t.Log("Actual", fmt.Sprintf("%+v", f.Inputs))
 		for _, d := range diff {
-			log.Debug("Diff", d)
+			t.Log("Diff", d)
 		}
 		t.Fatal("unexpected mapper inputs")
 	}
@@ -147,19 +147,19 @@ func TestMapTask(t *testing.T) {
 	}
 
 	if diff := deep.Equal(f.Outputs, eo); diff != nil {
-		log.Debug("Expected", fmt.Sprintf("%+v", eo))
-		log.Debug("Actual", fmt.Sprintf("%+v", f.Outputs))
+		t.Log("Expected", fmt.Sprintf("%+v", eo))
+		t.Log("Actual", fmt.Sprintf("%+v", f.Outputs))
 		for _, d := range diff {
-			log.Debug("Diff", d)
+			t.Log("Diff", d)
 		}
 		t.Fatal("unexpected mapper outputs")
 	}
 
 	if diff := deep.Equal(f.Volumes, ev); diff != nil {
-		log.Debug("Expected", fmt.Sprintf("%+v", ev))
-		log.Debug("Actual", fmt.Sprintf("%+v", f.Volumes))
+		t.Log("Expected", fmt.Sprintf("%+v", ev))
+		t.Log("Actual", fmt.Sprintf("%+v", f.Volumes))
 		for _, d := range diff {
-			log.Debug("Diff", d)
+			t.Log("Diff", d)
 		}
 		t.Fatal("unexpected mapper volumes")
 	}

--- a/worker/interfaces.go
+++ b/worker/interfaces.go
@@ -15,18 +15,16 @@ type Runner interface {
 	Run(context.Context)
 }
 
-// TaskService is a type which reads and writes task information
-// during task execution.
-type TaskService interface {
-	TaskLogger
-
+// TaskReader is a type which reads task information during task execution.
+type TaskReader interface {
 	Task() (*tes.Task, error)
 	State() tes.State
-	SetState(tes.State) error
 }
 
-// TaskLogger provides write access to a task's logs.
-type TaskLogger interface {
+// TaskWriter provides write access to a task's logs.
+type TaskWriter interface {
+	State(tes.State)
+
 	StartTime(t time.Time)
 	EndTime(t time.Time)
 	Outputs(o []*tes.OutputFileLog)

--- a/worker/log.go
+++ b/worker/log.go
@@ -1,5 +1,0 @@
-package worker
-
-import "github.com/ohsu-comp-bio/funnel/logger"
-
-var log = logger.Sub("worker")

--- a/worker/rpc_task.go
+++ b/worker/rpc_task.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"github.com/ohsu-comp-bio/funnel/config"
+	"github.com/ohsu-comp-bio/funnel/logger"
 	pbf "github.com/ohsu-comp-bio/funnel/proto/funnel"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
 	"github.com/ohsu-comp-bio/funnel/util"
@@ -17,14 +18,15 @@ type RPCTask struct {
 	client        *taskClient
 	taskID        string
 	updateTimeout time.Duration
+	log           logger.Logger
 }
 
-func newRPCTask(conf config.Worker, taskID string) (*RPCTask, error) {
+func newRPCTask(conf config.Worker, taskID string, log logger.Logger) (*RPCTask, error) {
 	client, err := newTaskClient(conf)
 	if err != nil {
 		return nil, err
 	}
-	return &RPCTask{client, taskID, conf.UpdateTimeout}, nil
+	return &RPCTask{client, taskID, conf.UpdateTimeout, log}, nil
 }
 
 // Task returns the task descriptor.
@@ -173,7 +175,7 @@ func (r *RPCTask) updateExecutorLogs(up *pbf.UpdateExecutorLogsRequest) error {
 	ctx, cleanup := context.WithTimeout(context.Background(), r.updateTimeout)
 	_, err := r.client.UpdateExecutorLogs(ctx, up)
 	if err != nil {
-		log.Error("Couldn't update executor logs", err)
+		r.log.Error("Couldn't update executor logs", err)
 	}
 	cleanup()
 	return err
@@ -183,7 +185,7 @@ func (r *RPCTask) updateTaskLogs(up *pbf.UpdateTaskLogsRequest) error {
 	ctx, cleanup := context.WithTimeout(context.Background(), r.updateTimeout)
 	_, err := r.client.UpdateTaskLogs(ctx, up)
 	if err != nil {
-		log.Error("Couldn't update task logs", err)
+		r.log.Error("Couldn't update task logs", err)
 	}
 	cleanup()
 	return err

--- a/worker/step.go
+++ b/worker/step.go
@@ -9,21 +9,20 @@ import (
 )
 
 type stepRunner struct {
-	TaskID     string
-	Conf       config.Worker
-	Num        int
-	Cmd        *DockerCmd
-	Log        logger.Logger
-	TaskLogger TaskLogger
-	IP         string
+	Conf  config.Worker
+	Num   int
+	Cmd   *DockerCmd
+	Log   logger.Logger
+	Write TaskWriter
+	IP    string
 }
 
 func (s *stepRunner) Run(ctx context.Context) error {
 	s.Log.Debug("Running step")
 
 	// Send update for host IP address.
-	s.TaskLogger.ExecutorStartTime(s.Num, time.Now())
-	s.TaskLogger.ExecutorHostIP(s.Num, s.IP)
+	s.Write.ExecutorStartTime(s.Num, time.Now())
+	s.Write.ExecutorHostIP(s.Num, s.IP)
 
 	// subctx helps ensure that these goroutines are cleaned up,
 	// even when the task is canceled.
@@ -54,7 +53,7 @@ func (s *stepRunner) Run(ctx context.Context) error {
 			// Likely the task was canceled.
 			s.Log.Info("Stopping container", "container", s.Cmd.ContainerName)
 			s.Cmd.Stop()
-			s.TaskLogger.ExecutorEndTime(s.Num, time.Now())
+			s.Write.ExecutorEndTime(s.Num, time.Now())
 			return ctx.Err()
 
 		case <-ticker.C:
@@ -62,13 +61,13 @@ func (s *stepRunner) Run(ctx context.Context) error {
 			stderr.Flush()
 
 		case result := <-done:
-			s.TaskLogger.ExecutorEndTime(s.Num, time.Now())
+			s.Write.ExecutorEndTime(s.Num, time.Now())
 			code, ok := getExitCode(result)
 			if !ok {
 				s.Log.Info("Could not determine exit code. Using default -999", "result", result)
 				code = -999
 			}
-			s.TaskLogger.ExecutorExitCode(s.Num, code)
+			s.Write.ExecutorExitCode(s.Num, code)
 			return result
 		}
 	}
@@ -76,10 +75,10 @@ func (s *stepRunner) Run(ctx context.Context) error {
 
 func (s *stepRunner) logTails() (*tailer, *tailer) {
 	stdout, _ := newTailer(s.Conf.LogTailSize, func(c string) {
-		s.TaskLogger.AppendExecutorStdout(s.Num, c)
+		s.Write.AppendExecutorStdout(s.Num, c)
 	})
 	stderr, _ := newTailer(s.Conf.LogTailSize, func(c string) {
-		s.TaskLogger.AppendExecutorStderr(s.Num, c)
+		s.Write.AppendExecutorStderr(s.Num, c)
 	})
 	if s.Cmd.Stdout != nil {
 		s.Cmd.Stdout = io.MultiWriter(s.Cmd.Stdout, stdout)
@@ -105,7 +104,7 @@ func (s *stepRunner) inspectContainer(ctx context.Context) {
 				break
 			}
 
-			s.TaskLogger.ExecutorPorts(s.Num, ports)
+			s.Write.ExecutorPorts(s.Num, ports)
 			return
 		}
 	}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -4,16 +4,11 @@ import (
 	"context"
 	"errors"
 	"github.com/ohsu-comp-bio/funnel/config"
-	"github.com/ohsu-comp-bio/funnel/logger"
 	pbf "github.com/ohsu-comp-bio/funnel/proto/funnel"
 	"github.com/stretchr/testify/mock"
 	"testing"
 	"time"
 )
-
-func init() {
-	log.Configure(logger.DebugConfig())
-}
 
 // Test calling stopping a worker by canceling its context
 func TestStopWorker(t *testing.T) {
@@ -117,7 +112,7 @@ func TestWorkerRunnerCreated(t *testing.T) {
 	w.sync(context.Background())
 	time.Sleep(time.Second)
 
-	log.Debug("COUNT", count)
+	t.Log("COUNT", count)
 	if count != 2 {
 		t.Fatal("Unexpected worker runner count")
 	}
@@ -140,7 +135,7 @@ func TestFinishedTaskNotRerun(t *testing.T) {
 	w.sync(context.Background())
 	time.Sleep(time.Second)
 
-	log.Debug("COUNT", w.runners.Count())
+	t.Log("COUNT", w.runners.Count())
 	if w.runners.Count() != 0 {
 		t.Fatal("Unexpected runner count")
 	}
@@ -151,7 +146,7 @@ func TestFinishedTaskNotRerun(t *testing.T) {
 	w.sync(context.Background())
 	time.Sleep(time.Second)
 
-	log.Debug("COUNT", w.runners.Count())
+	t.Log("COUNT", w.runners.Count())
 	if w.runners.Count() != 0 {
 		t.Fatal("Unexpected runner count")
 	}
@@ -174,7 +169,7 @@ func TestFinishedTaskRunsetCount(t *testing.T) {
 	time.Sleep(time.Second)
 
 	if w.runners.Count() != 0 {
-		log.Debug("COUNT", w.runners.Count())
+		t.Log("COUNT", w.runners.Count())
 		t.Fatal("Unexpected runner count")
 	}
 }


### PR DESCRIPTION
This PR attempts to clean up the TaskService interface by splitting it into two new/renamed interfaces: TaskReader and TaskWriter.

The main motivation here is to allow me to more easily see all the logs related to a task worker/runner in one place. Currently, I get part of the info from GetTask, and the other part from Kibana, which makes debugging failed tasks more difficult.

By separating these two, I can easily write a second TaskWriter which emits log messages via Funnel's logger package. This writer can be composed with the RPC-based writer, to allow both updates and log messages.

An important note is that `TaskService.SetState` moves to `TaskWriter.State`, which was the main reason I ended up renaming and reorganizing the entire interfaces (`TaskLogger.State` would have conflicted with `TaskService.State`). Also, the names are much cleaner now, I think.

Based on the worker logging cleanup branch from #201 