### PR TITLE
clean up errors during local node start

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-*.pb.go -diff
-mocks/*_mock.go
+*.pb.go -diff linguist-generated=true
+mocks/*_mock.go -diff linguist-generated=true
+cmd/version/data.go -diff linguist-generated=true

--- a/cmd/version/data.go
+++ b/cmd/version/data.go
@@ -2,8 +2,8 @@ package version
 
 // Build and version details
 const (
-	GitCommit = "ef02e23"
-	GitBranch = "versioning"
-	BuildDate = "Fri Sep  8 13:21:21 PDT 2017"
-	Version   = "0.2.0-20-gef02e23-dirty"
+	GitCommit = "b95954b"
+	GitBranch = "server-start-rpc-err"
+	BuildDate = "Sat Sep  9 10:33:41 PDT 2017"
+	Version   = "0.2.0-23-gb95954b-dirty"
 )

--- a/scheduler/node.go
+++ b/scheduler/node.go
@@ -79,6 +79,7 @@ func (n *Node) Run(ctx context.Context) {
 	n.log.Info("Starting node")
 	n.state = pbs.NodeState_ALIVE
 	n.checkConnection(ctx)
+	n.sync(ctx)
 
 	ticker := time.NewTicker(n.conf.UpdateRate)
 	defer ticker.Stop()
@@ -110,7 +111,9 @@ func (n *Node) Run(ctx context.Context) {
 func (n *Node) checkConnection(ctx context.Context) {
 	_, err := n.client.GetNode(ctx, &pbs.GetNodeRequest{Id: n.conf.ID})
 
-	if err != nil {
+	// If its a 404 error create a new node
+	s, _ := status.FromError(err)
+	if s.Code() != codes.NotFound {
 		log.Error("Couldn't contact server.", err)
 	} else {
 		log.Info("Successfully connected to server.")

--- a/server/scheduler_boltdb.go
+++ b/server/scheduler_boltdb.go
@@ -183,7 +183,7 @@ func (taskBolt *TaskBolt) GetNode(ctx context.Context, req *pbs.GetNodeRequest) 
 		return nil
 	})
 	if err != nil {
-		log.Error("GetNode", "error", err, "nodeID", req.Id)
+		log.Debug("GetNode", "error", err, "nodeID", req.Id)
 		if err == errNotFound {
 			return nil, grpc.Errorf(codes.NotFound, fmt.Sprintf("%v: nodeID: %s", err.Error(), req.Id))
 		}


### PR DESCRIPTION
This fixes few errors had made their way into the logs coming from `funnel server`.

Also, the Node immediately calls `sync()` instead of waiting for the first timer tick (5 seconds)
