### PR TITLE
Clean dead nodes on signal and timeout

### DIFF
--- a/cmd/node/run.go
+++ b/cmd/node/run.go
@@ -6,7 +6,9 @@ import (
 	"github.com/ohsu-comp-bio/funnel/compute/scheduler"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/logger"
+	"github.com/ohsu-comp-bio/funnel/util"
 	"github.com/spf13/cobra"
+	"syscall"
 )
 
 var configFile string
@@ -60,6 +62,9 @@ func Run(conf config.Config) error {
 		return err
 	}
 
-	n.Run(context.Background())
+	ctx := context.Background()
+	ctx = util.SignalContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	n.Run(ctx)
+
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ func DefaultConfig() Config {
 			ScheduleChunk:   10,
 			NodePingTimeout: time.Minute,
 			NodeInitTimeout: time.Minute * 5,
+			NodeDeadTimeout: time.Minute * 5,
 			Node: Node{
 				WorkDir:       workDir,
 				Timeout:       -1,
@@ -164,6 +165,8 @@ type Scheduler struct {
 	NodePingTimeout time.Duration
 	// How long to wait for node initialization before marking it dead
 	NodeInitTimeout time.Duration
+	// How long to wait before deleting a dead node from the DB.
+	NodeDeadTimeout time.Duration
 	// Node configuration
 	Node Node
 	// Logger configuration

--- a/server/scheduler_boltdb.go
+++ b/server/scheduler_boltdb.go
@@ -241,6 +241,12 @@ func (taskBolt *TaskBolt) CheckNodes() error {
 					// Looks like the node failed to initialize. Mark it dead
 					node.State = pbs.NodeState_DEAD
 				}
+			} else if node.State == pbs.NodeState_DEAD &&
+				// The node has been dead for long enough, delete it.
+				d > taskBolt.conf.Scheduler.NodeDeadTimeout {
+				tx.Bucket(Nodes).Delete(k)
+				continue
+
 			} else if d > taskBolt.conf.Scheduler.NodePingTimeout {
 				// The node is stale/dead
 				node.State = pbs.NodeState_DEAD

--- a/tests/e2e/node/node_test.go
+++ b/tests/e2e/node/node_test.go
@@ -1,0 +1,48 @@
+package node
+
+import (
+	"context"
+	"github.com/ohsu-comp-bio/funnel/compute/scheduler"
+	"github.com/ohsu-comp-bio/funnel/tests/e2e"
+	"testing"
+	"time"
+)
+
+// When the node's context is canceled (e.g. because the process
+// is being killed) the node should signal the database/server
+// that it is gone, and the server will delete the node.
+func TestNodeGoneOnCanceledContext(t *testing.T) {
+	conf := e2e.DefaultConfig()
+	conf.Scheduler.NodeInitTimeout = time.Second * 10
+	conf.Scheduler.NodePingTimeout = time.Second * 10
+	conf.Scheduler.NodeDeadTimeout = time.Second * 10
+
+	srv := e2e.NewFunnel(conf)
+	srv.StartServer()
+
+	srv.Conf.Scheduler.Node.ID = "test-node-gone-on-cancel"
+	n, err := scheduler.NewNode(srv.Conf)
+	if err != nil {
+		t.Fatal("failed to start node")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go n.Run(ctx)
+
+	srv.DB.CheckNodes()
+	time.Sleep(conf.Scheduler.Node.UpdateRate * 2)
+
+	nodes := srv.ListNodes()
+	if len(nodes) != 1 {
+		t.Fatal("failed to register node", nodes)
+	}
+
+	cancel()
+	time.Sleep(conf.Scheduler.Node.UpdateRate * 2)
+	srv.DB.CheckNodes()
+	nodes = srv.ListNodes()
+
+	if len(nodes) != 0 {
+		t.Error("expected node to be deleted")
+	}
+}

--- a/util/sigctx.go
+++ b/util/sigctx.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+// SignalContext will cancel the context when any of the given
+// signals is received.
+func SignalContext(ctx context.Context, sigs ...os.Signal) context.Context {
+	sch := make(chan os.Signal, 1)
+	sub, cancel := context.WithCancel(ctx)
+
+	signal.Notify(sch, sigs...)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-sch:
+			cancel()
+			return
+		}
+	}()
+	return sub
+}


### PR DESCRIPTION
This improves our handling of dead nodes:
- `node run` now watches for SIGINT and SIGTERM (canceled process) and cancels the node's context. The node the tells the server it's gone, which deletes it from the DB.
- Adds a check for nodes that have been dead for more than 5 minutes, at which point they are deleted.

Hopefully, this will help us handle preempted tasks in the future.