### PR TITLE
OutputFileLog.path container path bug fix

### DIFF
--- a/storage/gs.go
+++ b/storage/gs.go
@@ -114,51 +114,8 @@ func download(call *storage.ObjectsGetCall, hostPath string) error {
 	return nil
 }
 
-// Put copies an object (file) from the host path to GS.
-func (gs *GSBackend) Put(ctx context.Context, rawurl string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
-	var out []*tes.OutputFileLog
-
-	switch class {
-	case File:
-		err := gs.put(ctx, rawurl, hostPath)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, &tes.OutputFileLog{
-			Url:       rawurl,
-			Path:      hostPath,
-			SizeBytes: fileSize(hostPath),
-		})
-
-	case Directory:
-		files, err := walkFiles(hostPath)
-
-		for _, f := range files {
-			u := rawurl + "/" + f.rel
-			out = append(out, &tes.OutputFileLog{
-				Url:       u,
-				Path:      f.abs,
-				SizeBytes: f.size,
-			})
-			err := gs.put(ctx, u, f.abs)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-	default:
-		return nil, fmt.Errorf("Unknown file class: %s", class)
-	}
-
-	return out, nil
-}
-
-func (gs *GSBackend) put(ctx context.Context, rawurl, hostPath string) error {
-
+// PutFile copies an object (file) from the host path to GS.
+func (gs *GSBackend) PutFile(ctx context.Context, rawurl string, hostPath string) error {
 	url, perr := parse(rawurl)
 	if perr != nil {
 		return perr

--- a/storage/gs_test.go
+++ b/storage/gs_test.go
@@ -30,10 +30,11 @@ func authed(t *testing.T) *GSBackend {
 func TestAnonymousGet(t *testing.T) {
 	ctx := context.Background()
 	conf := config.GSStorage{}
-	gs, err := NewGSBackend(conf)
+	g, err := NewGSBackend(conf)
 	if err != nil {
 		t.Fatal(err)
 	}
+	gs := Storage{}.WithBackend(g)
 
 	gerr := gs.Get(ctx, "gs://uspto-pair/applications/05900016.zip", "_test_download/05900016.zip", tes.FileType_FILE)
 	if gerr != nil {
@@ -43,7 +44,8 @@ func TestAnonymousGet(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	ctx := context.Background()
-	gs := authed(t)
+	g := authed(t)
+	gs := Storage{}.WithBackend(g)
 
 	gerr := gs.Get(ctx, "gs://uspto-pair/applications/05900016.zip", "_test_download/downloaded", tes.FileType_FILE)
 	if gerr != nil {
@@ -53,7 +55,8 @@ func TestGet(t *testing.T) {
 
 func TestPut(t *testing.T) {
 	ctx := context.Background()
-	gs := authed(t)
+	g := authed(t)
+	gs := Storage{}.WithBackend(g)
 
 	_, gerr := gs.Put(ctx, "gs://ohsu-cromwell-testing.appspot.com/go_test_put", "_test_files/for_put", tes.FileType_FILE)
 	if gerr != nil {
@@ -63,7 +66,8 @@ func TestPut(t *testing.T) {
 
 func TestTrimSlashes(t *testing.T) {
 	ctx := context.Background()
-	gs := authed(t)
+	g := authed(t)
+	gs := Storage{}.WithBackend(g)
 
 	_, gerr := gs.Put(ctx, "gs://ohsu-cromwell-testing.appspot.com///go_test_put", "_test_files/for_put", tes.FileType_FILE)
 	if gerr != nil {

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -29,7 +29,7 @@ func TestLocalGet(t *testing.T) {
 		t.Fatal(err)
 	}
 	logger.Debug("TEMP DIR", tmp)
-	l := LocalBackend{allowedDirs: []string{tmp}}
+	l := Storage{}.WithBackend(&LocalBackend{allowedDirs: []string{tmp}})
 
 	// File test
 	ip := path.Join(tmp, "input.txt")
@@ -78,7 +78,7 @@ func TestLocalGetPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	logger.Debug("TEMP DIR", tmp)
-	l := LocalBackend{allowedDirs: []string{tmp}}
+	l := Storage{}.WithBackend(&LocalBackend{allowedDirs: []string{tmp}})
 
 	ip := path.Join(tmp, "input.txt")
 	cp := path.Join(tmp, "container.txt")
@@ -106,7 +106,7 @@ func TestLocalPut(t *testing.T) {
 		t.Fatal(err)
 	}
 	logger.Debug("TEMP DIR", tmp)
-	l := LocalBackend{allowedDirs: []string{tmp}}
+	l := Storage{}.WithBackend(&LocalBackend{allowedDirs: []string{tmp}})
 
 	// File test
 	cp := path.Join(tmp, "container.txt")
@@ -132,7 +132,6 @@ func TestLocalPut(t *testing.T) {
 	cdf := path.Join(cd, "other.txt")
 	od := path.Join(tmp, "subout")
 	ioutil.WriteFile(cdf, []byte("bar"), os.ModePerm)
-
 	_, gerr = l.Put(ctx, "file://"+od, cd, tes.FileType_DIRECTORY)
 	if gerr != nil {
 		t.Fatal(gerr)
@@ -155,7 +154,7 @@ func TestLocalPutPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	logger.Debug("TEMP DIR", tmp)
-	l := LocalBackend{allowedDirs: []string{tmp}}
+	l := Storage{}.WithBackend(&LocalBackend{allowedDirs: []string{tmp}})
 
 	cp := path.Join(tmp, "container.txt")
 	op := path.Join(tmp, "output.txt")

--- a/storage/swift.go
+++ b/storage/swift.go
@@ -113,53 +113,8 @@ func (sw *SwiftBackend) get(src io.Reader, hostPath string) error {
 	return dest.Close()
 }
 
-// Put copies an object (file) from the host path to storage.
-func (sw *SwiftBackend) Put(ctx context.Context, rawurl string, hostPath string, class tes.FileType) ([]*tes.OutputFileLog, error) {
-
-	var out []*tes.OutputFileLog
-
-	switch class {
-	case tes.FileType_FILE:
-
-		err := sw.put(rawurl, hostPath)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, &tes.OutputFileLog{
-			Url:       rawurl,
-			Path:      hostPath,
-			SizeBytes: fileSize(hostPath),
-		})
-
-	case tes.FileType_DIRECTORY:
-		files, err := walkFiles(hostPath)
-
-		for _, f := range files {
-			u := rawurl + "/" + f.rel
-			out = append(out, &tes.OutputFileLog{
-				Url:       u,
-				Path:      f.abs,
-				SizeBytes: f.size,
-			})
-			err := sw.put(u, f.abs)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-	default:
-		return nil, fmt.Errorf("Unknown file class: %s", class)
-	}
-
-	return out, nil
-}
-
-func (sw *SwiftBackend) put(rawurl, hostPath string) error {
-
+// PutFile copies an object (file) from the host path to storage.
+func (sw *SwiftBackend) PutFile(ctx context.Context, rawurl string, hostPath string) error {
 	url, perr := sw.parse(rawurl)
 	if perr != nil {
 		return perr

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -86,7 +86,7 @@ func TestS3StorageTask(t *testing.T) {
 		t.Fatal("Unexpected task failure")
 	}
 
-	expected := "/opt/inputs/test-file.txt /opt/inputs/test-directory/bar.txt /opt/inputs/test-directory/foo.txt\n"
+	expected := "/opt/inputs/test-directory/bar.txt /opt/inputs/test-directory/foo.txt /opt/inputs/test-file.txt\n"
 
 	s := storage.Storage{}
 	s, err = s.WithConfig(conf.Worker.Storage)

--- a/worker/file_mapper.go
+++ b/worker/file_mapper.go
@@ -273,3 +273,14 @@ func (mapper *FileMapper) AddOutput(output *tes.TaskParameter) error {
 func (mapper *FileMapper) IsSubpath(p string, base string) bool {
 	return strings.HasPrefix(p, base)
 }
+
+// ContainerPath returns an unmapped path.
+//
+// The mapper's base dir is stripped from the path.
+// e.g. If the mapper is configured with a base dir of "/tmp/mapped_files", then
+// mapper.ContainerPath("/tmp/mapped_files/home/ubuntu/myfile") will return "/home/ubuntu/myfile".
+func (mapper *FileMapper) ContainerPath(src string) string {
+	p := strings.TrimPrefix(src, mapper.dir)
+	p = path.Clean("/" + p)
+	return p
+}

--- a/worker/file_mapper_test.go
+++ b/worker/file_mapper_test.go
@@ -158,4 +158,10 @@ func TestMapTask(t *testing.T) {
 		}
 		t.Fatal("unexpected mapper volumes")
 	}
+
+	if f.ContainerPath(f.Outputs[0].Path) != task.Outputs[0].Path {
+		t.Log("Expected", task.Outputs[0].Path)
+		t.Log("Actual", f.ContainerPath(f.Outputs[0].Path))
+		t.Fatal("path unmapping failed")
+	}
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -185,6 +185,10 @@ func (r *DefaultWorker) Run(pctx context.Context) {
 			outputs = append(outputs, out...)
 		}
 	}
+	// unmap paths for OutputFileLog
+	for _, o := range outputs {
+		o.Path = r.Mapper.ContainerPath(o.Path)
+	}
 
 	if run.ok() {
 		r.Event.Outputs(outputs)


### PR DESCRIPTION
- deduplicated storage code for put
- report container paths in OutputFileLog

closes #290 