### PR TITLE
Handle node worker err

### DIFF
--- a/compute/scheduler/node.go
+++ b/compute/scheduler/node.go
@@ -223,6 +223,12 @@ func (n *Node) runTask(ctx context.Context, id string) {
 		}
 	}()
 
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("caught panic task worker", r)
+		}
+	}()
+
 	r, err := n.newWorker(n.workerConf, id, log)
 	if err != nil {
 		log.Error("error creating worker", err)

--- a/compute/scheduler/node.go
+++ b/compute/scheduler/node.go
@@ -180,49 +180,55 @@ func (n *Node) sync(ctx context.Context) {
 
 func (n *Node) runTask(ctx context.Context, id string) {
 	log := n.log.WithFields("ns", "worker", "taskID", id)
-	// TODO handle error
-	r, _ := n.newWorker(n.workerConf, id, log)
-	r.Run(ctx)
+
 	defer n.workers.Remove(id)
-
-	// task cannot fully complete until it has successfully removed the
-	// assigned ID from the node database. this helps prevent tasks from
-	// running multiple times.
-	ticker := time.NewTicker(n.conf.UpdateRate)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			r, err := n.client.GetNode(ctx, &pbs.GetNodeRequest{Id: n.conf.ID})
-			if err != nil {
-				log.Error("couldn't get node state during task sync.", err)
-				// break out of "select", but not "for".
-				// i.e. try again later
-				break
-			}
-
-			// Find the finished task ID in the node's assigned IDs and remove it.
-			var ids []string
-			for _, tid := range r.TaskIds {
-				if tid != id {
-					ids = append(ids, tid)
+	defer func() {
+		// task cannot fully complete until it has successfully removed the
+		// assigned ID from the node database. this helps prevent tasks from
+		// running multiple times.
+		ticker := time.NewTicker(n.conf.UpdateRate)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r, err := n.client.GetNode(ctx, &pbs.GetNodeRequest{Id: n.conf.ID})
+				if err != nil {
+					log.Error("couldn't get node state during task sync.", err)
+					// break out of "select", but not "for".
+					// i.e. try again later
+					break
 				}
-			}
-			r.TaskIds = ids
 
-			_, err = n.client.PutNode(ctx, r)
-			if err != nil {
-				log.Error("couldn't save node update during task sync.", err)
-				// break out of "select", but not "for".
-				// i.e. try again later
-				break
+				// Find the finished task ID in the node's assigned IDs and remove it.
+				var ids []string
+				for _, tid := range r.TaskIds {
+					if tid != id {
+						ids = append(ids, tid)
+					}
+				}
+				r.TaskIds = ids
+
+				_, err = n.client.PutNode(ctx, r)
+				if err != nil {
+					log.Error("couldn't save node update during task sync.", err)
+					// break out of "select", but not "for".
+					// i.e. try again later
+					break
+				}
+				// Update was successful, return.
+				return
 			}
-			// Update was successful, return.
-			return
 		}
+	}()
+
+	r, err := n.newWorker(n.workerConf, id, log)
+	if err != nil {
+		log.Error("error creating worker", err)
+		return
 	}
+	r.Run(ctx)
 }
 
 // Check if the node is idle. If so, start the timeout timer.


### PR DESCRIPTION
Handle the error from newWorker by logging it. Move the post-task handling to a defer to ensure the task ID always gets cleaned up. Also catch a panic.

Not a full solution, but an improvement.