### PR TITLE
logger: log protobuf as json if possible

### DIFF
--- a/logger/text_formatter.go
+++ b/logger/text_formatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/Sirupsen/logrus"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/logrusorgru/aurora"
@@ -14,6 +15,9 @@ import (
 )
 
 var baseTimestamp = time.Now()
+var jsonmar = jsonpb.Marshaler{
+	Indent: "  ",
+}
 
 type textFormatter struct {
 	TextFormatConfig
@@ -90,7 +94,11 @@ func (f *textFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		case float64:
 		case bool:
 		case proto.Message:
-			v = pretty.Sprint(x)
+			if s, err := jsonmar.MarshalToString(x); err == nil {
+				v = s
+			} else {
+				v = pretty.Sprint(x)
+			}
 		case fmt.Stringer:
 		case error:
 		default:


### PR DESCRIPTION
This will try to log protobuf messages as json, if possible, which makes makes them easier to read.

<img width="635" alt="screen shot 2017-11-07 at 4 20 48 pm" src="https://user-images.githubusercontent.com/262647/32525112-b8493cce-c3d7-11e7-870d-0866c26cf650.png">

<img width="485" alt="screen shot 2017-11-07 at 4 21 12 pm" src="https://user-images.githubusercontent.com/262647/32525118-bbb634b6-c3d7-11e7-9554-1da3d6de71cd.png">
