### PR TITLE
utils: move fs and docker utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ gen-mocks:
 bundle-examples:
 	@go-bindata -pkg examples -o examples/bundle.go $(shell find examples/ -name '*.json')
 	@go-bindata -pkg config -o config/bundle.go $(shell find config/ -name '*.txt' -o -name '*.yaml')
+	@gofmt -w -s examples/bundle.go config/bundle.go
 
 # Make everything usually needed to prepare for a pull request
 full: proto install prune_deps add_deps tidy lint test website webdash

--- a/cmd/worker/run.go
+++ b/cmd/worker/run.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ohsu-comp-bio/funnel/server/elastic"
 	"github.com/ohsu-comp-bio/funnel/server/mongodb"
 	"github.com/ohsu-comp-bio/funnel/storage"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"github.com/ohsu-comp-bio/funnel/worker"
 	"path"
 )
@@ -38,7 +38,7 @@ func NewDefaultWorker(conf config.Worker, taskID string, log *logger.Logger) (wo
 	// Map files into this baseDir
 	baseDir := path.Join(conf.WorkDir, taskID)
 
-	err = util.EnsureDir(baseDir)
+	err = fsutil.EnsureDir(baseDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create worker baseDir: %v", err)
 	}

--- a/compute/hpc_backend.go
+++ b/compute/hpc_backend.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"os"
 	"os/exec"
 	"path"
@@ -52,7 +52,7 @@ func (b *HPCBackend) setupTemplatedHPCSubmit(task *tes.Task) (string, error) {
 	// TODO document that these working dirs need manual cleanup
 	workdir := path.Join(b.conf.Worker.WorkDir, task.Id)
 	workdir, _ = filepath.Abs(workdir)
-	err = util.EnsureDir(workdir)
+	err = fsutil.EnsureDir(workdir)
 	if err != nil {
 		return "", err
 	}

--- a/compute/scheduler/node.go
+++ b/compute/scheduler/node.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ohsu-comp-bio/funnel/logger"
 	pbs "github.com/ohsu-comp-bio/funnel/proto/scheduler"
 	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"time"
@@ -21,7 +22,7 @@ func NewNode(conf config.Config, log *logger.Logger, factory WorkerFactory) (*No
 		return nil, err
 	}
 
-	err = util.EnsureDir(conf.Scheduler.Node.WorkDir)
+	err = fsutil.EnsureDir(conf.Scheduler.Node.WorkDir)
 	if err != nil {
 		return nil, err
 	}

--- a/config/bundle.go
+++ b/config/bundle.go
@@ -87,7 +87,7 @@ func configDefaultConfigYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/default-config.yaml", size: 9753, mode: os.FileMode(420), modTime: time.Unix(1511987589, 0)}
+	info := bindataFileInfo{name: "config/default-config.yaml", size: 9753, mode: os.FileMode(420), modTime: time.Unix(1511992815, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -107,7 +107,7 @@ func configGridengineTemplateTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/gridengine-template.txt", size: 377, mode: os.FileMode(420), modTime: time.Unix(1509037157, 0)}
+	info := bindataFileInfo{name: "config/gridengine-template.txt", size: 377, mode: os.FileMode(420), modTime: time.Unix(1510422945, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -127,7 +127,7 @@ func configHtcondorTemplateTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/htcondor-template.txt", size: 536, mode: os.FileMode(420), modTime: time.Unix(1509037157, 0)}
+	info := bindataFileInfo{name: "config/htcondor-template.txt", size: 536, mode: os.FileMode(420), modTime: time.Unix(1510422945, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -147,7 +147,7 @@ func configPbsTemplateTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/pbs-template.txt", size: 392, mode: os.FileMode(420), modTime: time.Unix(1509037157, 0)}
+	info := bindataFileInfo{name: "config/pbs-template.txt", size: 392, mode: os.FileMode(420), modTime: time.Unix(1510422945, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -167,7 +167,7 @@ func configSlurmTemplateTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/slurm-template.txt", size: 446, mode: os.FileMode(420), modTime: time.Unix(1509037157, 0)}
+	info := bindataFileInfo{name: "config/slurm-template.txt", size: 446, mode: os.FileMode(420), modTime: time.Unix(1510422945, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/examples/bundle.go
+++ b/examples/bundle.go
@@ -5,7 +5,6 @@
 // examples/input-content.json
 // examples/log-streaming.json
 // examples/md5sum.json
-// examples/openstack-swift.json
 // examples/resource-request.json
 // examples/s3.json
 // DO NOT EDIT!
@@ -90,7 +89,7 @@ func examplesGoogleStorageJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "examples/google-storage.json", size: 493, mode: os.FileMode(420), modTime: time.Unix(1510592440, 0)}
+	info := bindataFileInfo{name: "examples/google-storage.json", size: 493, mode: os.FileMode(420), modTime: time.Unix(1510983454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -110,7 +109,7 @@ func examplesHelloWorldJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "examples/hello-world.json", size: 218, mode: os.FileMode(420), modTime: time.Unix(1510592440, 0)}
+	info := bindataFileInfo{name: "examples/hello-world.json", size: 218, mode: os.FileMode(420), modTime: time.Unix(1510983454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -130,7 +129,7 @@ func examplesInputContentJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "examples/input-content.json", size: 736, mode: os.FileMode(420), modTime: time.Unix(1510592440, 0)}
+	info := bindataFileInfo{name: "examples/input-content.json", size: 736, mode: os.FileMode(420), modTime: time.Unix(1510983454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -150,7 +149,7 @@ func examplesLogStreamingJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "examples/log-streaming.json", size: 366, mode: os.FileMode(420), modTime: time.Unix(1510592440, 0)}
+	info := bindataFileInfo{name: "examples/log-streaming.json", size: 366, mode: os.FileMode(420), modTime: time.Unix(1510983454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -170,27 +169,7 @@ func examplesMd5sumJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "examples/md5sum.json", size: 731, mode: os.FileMode(420), modTime: time.Unix(1510592440, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
-var _examplesOpenstackSwiftJson = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x64\x90\xb1\x6e\xf3\x30\x0c\x84\x77\x3f\x05\xc1\x39\xf9\x3d\xfc\xe8\xe2\xb5\x6b\xa7\xa6\x9d\x8a\x0e\x8c\xc4\x24\x42\x2c\xc9\x10\x49\x34\x40\x90\x77\x2f\xc4\xb4\xce\xd0\x45\x90\x74\xc7\xbb\x0f\xbc\x0e\x00\x58\x28\x33\x4e\x80\xbb\xaf\x74\x50\xd8\x69\x6d\x74\x64\xe0\x0b\xe5\x65\x66\xdc\x74\x4b\x64\x09\x2d\x2d\x9a\x6a\xe9\xce\x37\x92\x33\xa4\xb2\x98\x0a\x50\x89\x50\x4d\xfd\x1e\xa8\xc0\x9e\xe1\x79\xae\x16\xd7\xa0\xf7\xd7\x17\xf9\x77\x8f\xe1\x0b\x07\xd3\xda\x04\x27\xf8\x18\x00\x00\xae\x7e\x02\x60\xca\x74\x74\x0a\xdb\x5b\x51\x73\xbf\x0b\xa1\xe6\x4c\x25\xf6\x09\xcc\xf1\x49\x2c\xe3\x06\x70\xd4\xbc\x8c\x87\x34\x33\x7e\xae\x4e\xd1\x58\x4d\x7b\x86\xab\x3f\x4f\x57\x6f\x03\x80\x1b\xf1\x4e\xfd\xb7\xff\x77\x09\xae\x3f\xda\xad\xcd\xfd\x57\xfe\x4f\xe3\x28\xda\x2c\x9c\x69\x2b\xa1\x91\x86\x93\x97\x28\x8b\x6e\x9d\x63\x1d\x59\x48\x4f\x2b\x84\x4b\x0f\x84\xe1\x36\x7c\x07\x00\x00\xff\xff\xc2\x44\xfa\x37\x73\x01\x00\x00")
-
-func examplesOpenstackSwiftJsonBytes() ([]byte, error) {
-	return bindataRead(
-		_examplesOpenstackSwiftJson,
-		"examples/openstack-swift.json",
-	)
-}
-
-func examplesOpenstackSwiftJson() (*asset, error) {
-	bytes, err := examplesOpenstackSwiftJsonBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "examples/openstack-swift.json", size: 371, mode: os.FileMode(420), modTime: time.Unix(1511208449, 0)}
+	info := bindataFileInfo{name: "examples/md5sum.json", size: 731, mode: os.FileMode(420), modTime: time.Unix(1510983454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -210,7 +189,7 @@ func examplesResourceRequestJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "examples/resource-request.json", size: 299, mode: os.FileMode(420), modTime: time.Unix(1510790492, 0)}
+	info := bindataFileInfo{name: "examples/resource-request.json", size: 299, mode: os.FileMode(420), modTime: time.Unix(1510983454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -230,7 +209,7 @@ func examplesS3Json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "examples/s3.json", size: 476, mode: os.FileMode(420), modTime: time.Unix(1510790492, 0)}
+	info := bindataFileInfo{name: "examples/s3.json", size: 476, mode: os.FileMode(420), modTime: time.Unix(1510983454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -292,7 +271,6 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/input-content.json":    examplesInputContentJson,
 	"examples/log-streaming.json":    examplesLogStreamingJson,
 	"examples/md5sum.json":           examplesMd5sumJson,
-	"examples/openstack-swift.json":  examplesOpenstackSwiftJson,
 	"examples/resource-request.json": examplesResourceRequestJson,
 	"examples/s3.json":               examplesS3Json,
 }
@@ -344,7 +322,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"input-content.json":    {examplesInputContentJson, map[string]*bintree{}},
 		"log-streaming.json":    {examplesLogStreamingJson, map[string]*bintree{}},
 		"md5sum.json":           {examplesMd5sumJson, map[string]*bintree{}},
-		"openstack-swift.json":  {examplesOpenstackSwiftJson, map[string]*bintree{}},
 		"resource-request.json": {examplesResourceRequestJson, map[string]*bintree{}},
 		"s3.json":               {examplesS3Json, map[string]*bintree{}},
 	}},

--- a/server/boltdb/new.go
+++ b/server/boltdb/new.go
@@ -4,7 +4,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/ohsu-comp-bio/funnel/compute"
 	"github.com/ohsu-comp-bio/funnel/config"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"golang.org/x/net/context"
 	"time"
 )
@@ -50,7 +50,7 @@ type BoltDB struct {
 // NewBoltDB returns a new instance of BoltDB, accessing the database at
 // the given path, and including the given ServerConfig.
 func NewBoltDB(conf config.Config) (*BoltDB, error) {
-	util.EnsurePath(conf.Server.Databases.BoltDB.Path)
+	fsutil.EnsurePath(conf.Server.Databases.BoltDB.Path)
 	db, err := bolt.Open(conf.Server.Databases.BoltDB.Path, 0600, &bolt.Options{
 		Timeout: time.Second * 5,
 	})

--- a/storage/gs.go
+++ b/storage/gs.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/storage/v1"
 	"io"
@@ -99,7 +99,7 @@ func download(call *storage.ObjectsGetCall, hostPath string) error {
 		return derr
 	}
 
-	util.EnsurePath(hostPath)
+	fsutil.EnsurePath(hostPath)
 	dest, cerr := os.Create(hostPath)
 	if cerr != nil {
 		return cerr

--- a/storage/swift.go
+++ b/storage/swift.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ncw/swift"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"io"
 	"os"
 	"path"
@@ -108,7 +108,7 @@ func (sw *SwiftBackend) Get(ctx context.Context, rawurl string, hostPath string,
 }
 
 func (sw *SwiftBackend) get(src io.Reader, hostPath string) error {
-	util.EnsurePath(hostPath)
+	fsutil.EnsurePath(hostPath)
 	dest, cerr := os.Create(hostPath)
 	if cerr != nil {
 		return cerr

--- a/tests/config_utils.go
+++ b/tests/config_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/logger"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -71,7 +71,7 @@ func TestifyConfig(conf config.Config) config.Config {
 	storageDir, _ := ioutil.TempDir("./test_tmp", "funnel-test-storage-")
 	wd, _ := os.Getwd()
 
-	util.EnsureDir(storageDir)
+	fsutil.EnsureDir(storageDir)
 
 	conf.Worker.Storage.Local = config.LocalStorage{
 		AllowedDirs: []string{storageDir, wd},

--- a/tests/funnel_utils.go
+++ b/tests/funnel_utils.go
@@ -16,7 +16,7 @@ import (
 	pbs "github.com/ohsu-comp-bio/funnel/proto/scheduler"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
 	"github.com/ohsu-comp-bio/funnel/server"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/dockerutil"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"io/ioutil"
@@ -66,7 +66,7 @@ type Funnel struct {
 func NewFunnel(conf config.Config) *Funnel {
 	conf = config.EnsureServerProperties(conf)
 
-	dcli, derr := util.NewDockerClient()
+	dcli, derr := dockerutil.NewDockerClient()
 	if derr != nil {
 		panic(derr)
 	}

--- a/util/dockerutil/docker.go
+++ b/util/dockerutil/docker.go
@@ -1,4 +1,4 @@
-package util
+package dockerutil
 
 import (
 	"context"

--- a/util/fsutil/dir.go
+++ b/util/fsutil/dir.go
@@ -1,4 +1,4 @@
-package util
+package fsutil
 
 import (
 	"os"

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/ohsu-comp-bio/funnel/events"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/dockerutil"
 	"io"
 	"os/exec"
 	"strings"
@@ -30,7 +30,7 @@ type DockerCommand struct {
 func (dcmd DockerCommand) Run() error {
 	// (Hopefully) temporary hack to sync docker API version info.
 	// Don't need the client here, just the logic inside NewDockerClient().
-	_, derr := util.NewDockerClient()
+	_, derr := dockerutil.NewDockerClient()
 	if derr != nil {
 		dcmd.Event.Error("Can't connect to Docker", derr)
 		return derr
@@ -86,7 +86,7 @@ func (dcmd DockerCommand) Run() error {
 // Stop stops the container.
 func (dcmd DockerCommand) Stop() error {
 	dcmd.Event.Info("Stopping container", "container", dcmd.ContainerName)
-	dclient, derr := util.NewDockerClient()
+	dclient, derr := dockerutil.NewDockerClient()
 	if derr != nil {
 		return derr
 	}

--- a/worker/file_mapper.go
+++ b/worker/file_mapper.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	proto "github.com/golang/protobuf/proto"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"io/ioutil"
 	"os"
 	"path"
@@ -162,7 +162,7 @@ func (mapper *FileMapper) CreateHostFile(src string) (*os.File, error) {
 	if perr != nil {
 		return nil, perr
 	}
-	err := util.EnsurePath(p)
+	err := fsutil.EnsurePath(p)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (mapper *FileMapper) AddTmpVolume(mountPoint string) error {
 		return err
 	}
 
-	err = util.EnsureDir(hostPath)
+	err = fsutil.EnsureDir(hostPath)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (mapper *FileMapper) AddInput(input *tes.Input) error {
 		return err
 	}
 
-	err = util.EnsurePath(hostPath)
+	err = fsutil.EnsurePath(hostPath)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func (mapper *FileMapper) AddOutput(output *tes.Output) error {
 		mountDir = path.Dir(output.Path)
 	}
 
-	err = util.EnsureDir(hostDir)
+	err = fsutil.EnsureDir(hostDir)
 	if err != nil {
 		return err
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ohsu-comp-bio/funnel/events"
 	"github.com/ohsu-comp-bio/funnel/proto/tes"
 	"github.com/ohsu-comp-bio/funnel/storage"
-	"github.com/ohsu-comp-bio/funnel/util"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -96,7 +96,7 @@ func (r *DefaultWorker) Run(pctx context.Context) {
 		dir, run.syserr = filepath.Abs(r.Conf.WorkDir)
 	}
 	if run.ok() {
-		run.syserr = util.EnsureDir(dir)
+		run.syserr = fsutil.EnsureDir(dir)
 	}
 
 	// Prepare file mapper, which maps task file URLs to host filesystem paths


### PR DESCRIPTION
I've been slowly working towards Appengine support. Appengine's sandbox takes issue with certain imports, such as `syscall`. This shuffles some utility code so that the server doesn't depend on these imports.