### PR TITLE
worker/rpc: close rpc clients

### DIFF
--- a/cmd/worker/run.go
+++ b/cmd/worker/run.go
@@ -19,7 +19,10 @@ import (
 
 // Run runs the "worker run" command.
 func Run(ctx context.Context, conf config.Config, taskID string, log *logger.Logger) error {
-	w, err := NewWorker(conf, taskID, log)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	w, err := NewWorker(ctx, conf, taskID, log)
 	if err != nil {
 		return err
 	}
@@ -28,13 +31,12 @@ func Run(ctx context.Context, conf config.Config, taskID string, log *logger.Log
 }
 
 // NewWorker returns a new Funnel worker based on the given config.
-func NewWorker(conf config.Config, taskID string, log *logger.Logger) (*worker.DefaultWorker, error) {
+func NewWorker(ctx context.Context, conf config.Config, taskID string, log *logger.Logger) (*worker.DefaultWorker, error) {
 	if log == nil {
 		log = logger.NewLogger("worker", conf.Logger)
 	}
 	log.Debug("NewWorker", "config", conf, "taskID", taskID)
 
-	ctx := context.Background()
 	var err error
 	var db tes.ReadOnlyServer
 	var reader worker.TaskReader

--- a/util/rpc/rpc.go
+++ b/util/rpc/rpc.go
@@ -53,10 +53,19 @@ func Dial(pctx context.Context, conf config.Server, opts ...grpc.DialOption) (*g
 		)),
 	)
 
-	return grpc.DialContext(ctx,
+	conn, err := grpc.DialContext(ctx,
 		conf.RPCAddress(),
 		opts...,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-pctx.Done()
+		conn.Close()
+	}()
+	return conn, nil
 }
 
 type exponentialBackoff struct {


### PR DESCRIPTION
Related to #184 

This closes rpc client connections made by each task worker.