### PR TITLE
logger/grpc: set most grpc logs to debug

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -60,6 +60,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := logger.NewLogger("node", conf.Logger)
+			logger.SetGRPCLogger(log)
 			ctx, cancel := context.WithCancel(context.Background())
 			ctx = util.SignalContext(ctx, time.Second*5, syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -58,6 +58,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := logger.NewLogger("server", conf.Logger)
+			logger.SetGRPCLogger(log)
 			ctx, cancel := context.WithCancel(context.Background())
 			ctx = util.SignalContext(ctx, time.Second*5, syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -63,6 +63,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 			}
 
 			log := logger.NewLogger("worker", conf.Logger)
+			logger.SetGRPCLogger(log)
 			ctx, cancel := context.WithCancel(context.Background())
 			ctx = util.SignalContext(ctx, time.Second*5, syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()

--- a/logger/grpc.go
+++ b/logger/grpc.go
@@ -8,43 +8,37 @@ import (
 
 func init() {
 	conf := DefaultConfig()
-	conf.Level = "warn"
-	ConfigureGRPC(2, NewLogger("grpc", conf))
+	conf.Level = ErrorLevel
+	SetGRPCLogger(NewLogger("grpc", conf))
 }
 
-// ConfigureGRPC configures the GRPC logger verboisty level.
-//   All logs in transport package only go to verbose level 2.
-//   All logs in other packages in grpc are logged in spite of the verbosity level.
-func ConfigureGRPC(verbosity int, log *Logger) {
-	grpclog.SetLoggerV2(&grpclogger{
-		verbosity: verbosity,
-		log:       log,
-	})
+// SetGRPCLogger sets the global GRPC logger.
+func SetGRPCLogger(l *Logger) {
+	grpclog.SetLoggerV2(&grpclogger{log: l})
 }
 
 // Configure the GRPC logger to use the global logrus configuration
 type grpclogger struct {
-	verbosity int
-	log       *Logger
+	log *Logger
 }
 
 func (g *grpclogger) Info(args ...interface{}) {
-	g.log.Info(fmt.Sprint(args))
+	g.log.Debug(fmt.Sprint(args))
 }
 func (g *grpclogger) Infoln(args ...interface{}) {
-	g.log.Info(fmt.Sprint(args))
+	g.log.Debug(fmt.Sprint(args))
 }
 func (g *grpclogger) Infof(format string, args ...interface{}) {
-	g.log.Info(fmt.Sprintf(format, args))
+	g.log.Debug(fmt.Sprintf(format, args))
 }
 func (g *grpclogger) Warning(args ...interface{}) {
-	g.log.Warn(fmt.Sprint(args))
+	g.log.Debug(fmt.Sprint(args))
 }
 func (g *grpclogger) Warningln(args ...interface{}) {
-	g.log.Warn(fmt.Sprint(args))
+	g.log.Debug(fmt.Sprint(args))
 }
 func (g *grpclogger) Warningf(format string, args ...interface{}) {
-	g.log.Warn(fmt.Sprintf(format, args))
+	g.log.Debug(fmt.Sprintf(format, args))
 }
 func (g *grpclogger) Error(args ...interface{}) {
 	g.log.Error(fmt.Sprint(args))
@@ -68,5 +62,5 @@ func (g *grpclogger) Fatalf(format string, args ...interface{}) {
 	os.Exit(1)
 }
 func (g *grpclogger) V(l int) bool {
-	return g.verbosity >= l
+	return true
 }

--- a/tests/funnel_utils.go
+++ b/tests/funnel_utils.go
@@ -33,7 +33,7 @@ import (
 var log = logger.NewLogger("e2e", LogConfig())
 
 func init() {
-	logger.ConfigureGRPC(1, logger.NewLogger("grpc", LogConfig()))
+	logger.SetGRPCLogger(log)
 }
 
 // Funnel provides a test server and RPC/HTTP clients


### PR DESCRIPTION
The grpc logs are a pain. In the screenshot below you can see they overwhelm the TravisCI test logs with pages of junk. This is an attempt to clean those up by moving most things to the debug level.

Perhaps one things that's missing is to call SetGRPCLogger in all the top-level commands such as server, node, and worker.

<img width="985" alt="screen shot 2018-01-24 at 4 53 51 pm" src="https://user-images.githubusercontent.com/262647/35365073-67da9fa2-0127-11e8-857f-733e414e7150.png">
