### PR TITLE
compute/scheduler: fix nil panic on error log

### DIFF
--- a/compute/scheduler/scheduler.go
+++ b/compute/scheduler/scheduler.go
@@ -63,18 +63,18 @@ func (s *Scheduler) CheckNodes() error {
 		if node.State == pbs.NodeState_GONE {
 			for _, tid := range node.TaskIds {
 				serr := s.Event.WriteEvent(ctx, events.NewState(tid, tes.State_SYSTEM_ERROR))
-				slerr := s.Event.WriteEvent(ctx, events.NewSystemLog(tid, 0, 0, "error",
-					"Cleaning up Task assigned to dead/gone node", map[string]string{
-						"nodeID": node.Id,
-					}))
-				if serr != nil || slerr != nil {
+				if serr != nil {
 					return fmt.Errorf(
 						"Error cleaning up task assigned to dead/gone node. taskID: %s nodeID: %s error: %v",
 						tid,
 						node.Id,
-						serr.Error()+"; "+slerr.Error(),
+						serr.Error(),
 					)
 				}
+				s.Event.WriteEvent(ctx, events.NewSystemLog(tid, 0, 0, "error",
+					"Cleaning up Task assigned to dead/gone node", map[string]string{
+						"nodeID": node.Id,
+					}))
 			}
 			_, err = s.Nodes.DeleteNode(ctx, node)
 		} else {


### PR DESCRIPTION
`slerr` or `serr` can be nil, which results in a panic when `err.Error()` is called.

`slerr` isn't really needed. It's ok if the system log drops.