### PR TITLE
databases: added Init method to interface

### DIFF
--- a/cmd/worker/run.go
+++ b/cmd/worker/run.go
@@ -54,7 +54,7 @@ func NewWorker(ctx context.Context, conf config.Config, log *logger.Logger) (*wo
 		case "datastore":
 			writer, err = datastore.NewDatastore(conf.Datastore)
 		case "elastic":
-			writer, err = elastic.NewElastic(ctx, conf.Elastic)
+			writer, err = elastic.NewElastic(conf.Elastic)
 		case "kafka":
 			writer, err = events.NewKafkaWriter(ctx, conf.Kafka)
 		case "pubsub":
@@ -71,6 +71,7 @@ func NewWorker(ctx context.Context, conf config.Config, log *logger.Logger) (*wo
 			writers = append(writers, writer)
 		}
 	}
+
 	writer = &events.SystemLogFilter{Writer: &writers, Level: conf.Logger.Level}
 	writer = &events.ErrLogger{Writer: writer, Log: log}
 
@@ -80,7 +81,7 @@ func NewWorker(ctx context.Context, conf config.Config, log *logger.Logger) (*wo
 	case "dynamodb":
 		db, err = dynamodb.NewDynamoDB(conf.DynamoDB)
 	case "elastic":
-		db, err = elastic.NewElastic(ctx, conf.Elastic)
+		db, err = elastic.NewElastic(conf.Elastic)
 	case "mongodb":
 		db, err = mongodb.NewMongoDB(conf.MongoDB)
 	case "boltdb":

--- a/server/boltdb/new.go
+++ b/server/boltdb/new.go
@@ -58,16 +58,11 @@ func NewBoltDB(conf config.BoltDB) (*BoltDB, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	b := &BoltDB{db: db}
-	if err := b.init(); err != nil {
-		return nil, err
-	}
-	return b, nil
+	return &BoltDB{db: db}, nil
 }
 
-// init creates the required BoltDB buckets
-func (taskBolt *BoltDB) init() error {
+// Init creates the required BoltDB buckets
+func (taskBolt *BoltDB) Init() error {
 	// Check to make sure all the required buckets have been created
 	return taskBolt.db.Update(func(tx *bolt.Tx) error {
 		if tx.Bucket(TaskBucket) == nil {

--- a/server/datastore/new.go
+++ b/server/datastore/new.go
@@ -28,3 +28,8 @@ func NewDatastore(conf config.Datastore) (*Datastore, error) {
 	}
 	return &Datastore{client}, nil
 }
+
+// Init is a noop action for Datastore.
+func (db *Datastore) Init() error {
+	return nil
+}

--- a/server/dynamodb/new.go
+++ b/server/dynamodb/new.go
@@ -40,8 +40,10 @@ func NewDynamoDB(conf config.DynamoDB) (*DynamoDB, error) {
 		syslogsTable:   conf.TableBasename + "-syslogs",
 	}
 
-	if err := db.createTables(); err != nil {
-		return nil, err
-	}
 	return db, nil
+}
+
+// Init creates tables in DynamoDB.
+func (db *DynamoDB) Init() error {
+	return db.createTables()
 }

--- a/server/elastic/new.go
+++ b/server/elastic/new.go
@@ -21,7 +21,7 @@ type Elastic struct {
 }
 
 // NewElastic returns a new Elastic instance.
-func NewElastic(ctx context.Context, conf config.Elastic) (*Elastic, error) {
+func NewElastic(conf config.Elastic) (*Elastic, error) {
 	client, err := elastic.NewClient(
 		elastic.SetURL(conf.URL),
 		elastic.SetSniff(false),
@@ -39,9 +39,6 @@ func NewElastic(ctx context.Context, conf config.Elastic) (*Elastic, error) {
 		conf,
 		conf.IndexPrefix + "-tasks",
 		conf.IndexPrefix + "-nodes",
-	}
-	if err := es.init(ctx); err != nil {
-		return nil, err
 	}
 	return es, nil
 }
@@ -67,8 +64,9 @@ func (es *Elastic) initIndex(ctx context.Context, name, body string) error {
 	return nil
 }
 
-// init initializing the Elasticsearch indices.
-func (es *Elastic) init(ctx context.Context) error {
+// Init creates the Elasticsearch indices.
+func (es *Elastic) Init() error {
+	ctx := context.Background()
 	taskMappings := `{
     "mappings": {
       "task":{

--- a/server/mongodb/new.go
+++ b/server/mongodb/new.go
@@ -37,14 +37,11 @@ func NewMongoDB(conf config.MongoDB) (*MongoDB, error) {
 		tasks: sess.DB(conf.Database).C("tasks"),
 		nodes: sess.DB(conf.Database).C("nodes"),
 	}
-	if err := db.init(); err != nil {
-		return nil, err
-	}
 	return db, nil
 }
 
-// init creates tables in MongoDB.
-func (db *MongoDB) init() error {
+// Init creates tables in MongoDB.
+func (db *MongoDB) Init() error {
 	names, err := db.sess.DB(db.conf.Database).CollectionNames()
 	if err != nil {
 		return fmt.Errorf("error listing collection names in database %s: %v", db.conf.Database, err)


### PR DESCRIPTION
Bringing back the `Init` method for our databases. This allows us to scope permissions for the worker differently than the server in cloud environments. 