### PR TITLE
server/elastic: fix tag filter to use keyword

### DIFF
--- a/server/elastic/tes.go
+++ b/server/elastic/tes.go
@@ -59,7 +59,7 @@ func (es *Elastic) ListTasks(ctx context.Context, req *tes.ListTasksRequest) (*t
 	}
 
 	for k, v := range req.Tags {
-		filterParts = append(filterParts, elastic.NewMatchQuery(fmt.Sprintf("tags.%s", k), v))
+		filterParts = append(filterParts, elastic.NewMatchQuery(fmt.Sprintf("tags.%s.keyword", k), v))
 	}
 
 	if len(filterParts) > 0 {

--- a/tests/core/basic_test.go
+++ b/tests/core/basic_test.go
@@ -721,10 +721,12 @@ func TestListTaskFilterTags(t *testing.T) {
 	id1 := f.Run(`'echo hello' --tag foo=bar`)
 	id2 := f.Run(`'echo hello' --tag foo=bar --tag hello=world`)
 	id3 := f.Run(`'echo hello'`)
+	id4 := f.Run(`'echo hello' --tag foo=bar-bar`)
 
 	f.Wait(id1)
 	f.Wait(id2)
 	f.Wait(id3)
+	f.Wait(id4)
 
 	r, err := f.HTTP.ListTasks(ctx, &tes.ListTasksRequest{
 		View: tes.Full,
@@ -737,7 +739,7 @@ func TestListTaskFilterTags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(r.Tasks) != 3 {
+	if len(r.Tasks) != 4 {
 		t.Error("unexpected all tasks", r.Tasks)
 	}
 


### PR DESCRIPTION
Elasticsearch wasn't correctly returning results from a tag filter