### PR TITLE
worker: always mount to /tmp in container

### DIFF
--- a/worker/docker.go
+++ b/worker/docker.go
@@ -40,7 +40,7 @@ func (dcmd DockerCommand) Run() error {
 	pullcmd := exec.Command("docker", "pull", dcmd.Image)
 	pullcmd.Run()
 
-	args := []string{"run", "-i"}
+	args := []string{"run", "-i", "--read-only"}
 
 	if dcmd.RemoveContainer {
 		args = append(args, "--rm")
@@ -68,7 +68,7 @@ func (dcmd DockerCommand) Run() error {
 	args = append(args, dcmd.Image)
 	args = append(args, dcmd.Command...)
 
-	// Roughly: `docker run --rm -i -w [workdir] -v [bindings] [imageName] [cmd]`
+	// Roughly: `docker run --rm -i --read-only -w [workdir] -v [bindings] [imageName] [cmd]`
 	dcmd.Event.Info("Running command", "cmd", "docker "+strings.Join(args, " "))
 	cmd := exec.Command("docker", args...)
 

--- a/worker/file_mapper.go
+++ b/worker/file_mapper.go
@@ -66,15 +66,20 @@ func (mapper *FileMapper) MapTask(task *tes.Task) error {
 
 	// Add all the volumes to the mapper
 	for _, vol := range task.Volumes {
-		err := mapper.AddTmpVolume(vol)
+		err = mapper.AddTmpVolume(vol)
 		if err != nil {
 			return err
 		}
 	}
 
+	err = mapper.AddTmpVolume("/tmp")
+	if err != nil {
+		return err
+	}
+
 	// Add all the inputs to the mapper
 	for _, input := range task.Inputs {
-		err := mapper.AddInput(input)
+		err = mapper.AddInput(input)
 		if err != nil {
 			return err
 		}
@@ -82,7 +87,7 @@ func (mapper *FileMapper) MapTask(task *tes.Task) error {
 
 	// Add all the outputs to the mapper
 	for _, output := range task.Outputs {
-		err := mapper.AddOutput(output)
+		err = mapper.AddOutput(output)
 		if err != nil {
 			return err
 		}

--- a/worker/file_mapper_test.go
+++ b/worker/file_mapper_test.go
@@ -104,6 +104,11 @@ func TestMapTask(t *testing.T) {
 			Readonly:      false,
 		},
 		{
+			HostPath:      tmp + "/tmp",
+			ContainerPath: "/tmp",
+			Readonly:      false,
+		},
+		{
 			HostPath:      tmp + "/opt/funnel/inputs/testdata/f1.txt",
 			ContainerPath: "/opt/funnel/inputs/testdata/f1.txt",
 			Readonly:      true,


### PR DESCRIPTION
This is a defensive measure since so many tools seem to write to this location. 

Additionally, I added the `--read-only` flag to the docker run command.  Any location that the command will write to should be declared in `volumes`, `inputs`, or `outputs` in the task message. 