### PR TITLE
docker: allow docker base command args to be configured

### DIFF
--- a/cmd/worker/run.go
+++ b/cmd/worker/run.go
@@ -106,6 +106,7 @@ func NewWorker(ctx context.Context, conf config.Config, log *logger.Logger) (*wo
 		Store:       store,
 		TaskReader:  reader,
 		EventWriter: writer,
+		DockerConf:  conf.Docker,
 	}
 
 	return w, nil

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,12 @@ type Config struct {
 	GoogleStorage GSStorage
 	Swift         SwiftStorage
 	HTTPStorage   HTTPStorage
+	Docker        Docker
+}
+
+type Docker struct {
+	BaseArgs       []string
+	LeaveContainer bool
 }
 
 // Server describes configuration for the server.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -22,6 +22,7 @@ import (
 // and logging.
 type DefaultWorker struct {
 	Conf        config.Worker
+	DockerConf  config.Docker
 	Store       storage.Storage
 	TaskReader  TaskReader
 	EventWriter events.Writer
@@ -157,15 +158,15 @@ func (r *DefaultWorker) Run(pctx context.Context, taskID string) (runerr error) 
 				Conf:  r.Conf,
 				Event: event.NewExecutorWriter(uint32(i)),
 				Command: &DockerCommand{
-					Image:         d.Image,
-					Command:       d.Command,
-					Env:           d.Env,
-					Volumes:       mapper.Volumes,
-					Workdir:       d.Workdir,
-					ContainerName: fmt.Sprintf("%s-%d", task.Id, i),
-					// TODO make RemoveContainer configurable
-					RemoveContainer: true,
-					Event:           event.NewExecutorWriter(uint32(i)),
+					Image:          d.Image,
+					Command:        d.Command,
+					Env:            d.Env,
+					Volumes:        mapper.Volumes,
+					Workdir:        d.Workdir,
+					ContainerName:  fmt.Sprintf("%s-%d", task.Id, i),
+					Event:          event.NewExecutorWriter(uint32(i)),
+					LeaveContainer: r.DockerConf.LeaveContainer,
+					BaseArgs:       r.DockerConf.BaseArgs,
 				},
 			}
 


### PR DESCRIPTION
There are cases where the standard "docker" command is not the appropriate/best command to execute for docker containers. Examples include custom docker wrappers such as exadocker, udocker, etc.

This changes allows config such as:
```
Docker:
  BaseArgs: ["sudo", "/path/to/docker-wrapper"]
```

This is what I'm thinking for allowing the docker command to be configured/overridden.

Note that since I'm touching the docker config, I modified the `RemoveContainer` flag, which was previously hard-coded to `true` and never exposed via config. This change exposes that as `config.Docker.LeaveContainer`.

Another minor tweak is that all os/exec commands in the docker executor now use CommandContext.

To do:
- [ ] update config example
- [ ] website docs
- [ ] tests