### PR TITLE
cmd: add completion command for bash completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Generate shell completion code",
+}
+
+var bash = &cobra.Command{
+	Use:   "bash",
+	Short: "Generate bash completion code",
+	Long: `This command generates bash CLI completion code.
+Add "source <(funnel completion bash)" to your bash profile.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		RootCmd.GenBashCompletion(os.Stdout)
+	},
+}
+
+func init() {
+	completionCmd.AddCommand(bash)
+}

--- a/cmd/gendocs.go
+++ b/cmd/gendocs.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -13,14 +11,5 @@ var genMarkdownCmd = &cobra.Command{
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return doc.GenMarkdownTree(RootCmd, "./funnel-cmd-docs")
-	},
-}
-
-var genBashCompletionCmd = &cobra.Command{
-	Use:    "genbash",
-	Short:  "generate bash completions for the funnel commands",
-	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		RootCmd.GenBashCompletion(os.Stdout)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ func init() {
 	RootCmd.AddCommand(aws.Cmd)
 	RootCmd.AddCommand(examples.Cmd)
 	RootCmd.AddCommand(gce.Cmd)
-	RootCmd.AddCommand(genBashCompletionCmd)
+	RootCmd.AddCommand(completionCmd)
 	RootCmd.AddCommand(genMarkdownCmd)
 	RootCmd.AddCommand(node.NewCommand())
 	RootCmd.AddCommand(run.Cmd)


### PR DESCRIPTION
I actually started using bash completion (finally). This remove the `Hidden` flag that was hiding the command, and organizes shell command completion under `funnel completion <shell>` e.g. `funnel completion bash`.

By the way, I use `source <(funnel completion bash)` in my profile.