### PR TITLE
config: handle error from ToYaml

### DIFF
--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/ohsu-comp-bio/funnel/cmd/util"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/logger"
 )
@@ -18,7 +19,7 @@ func TestPersistentPreRun(t *testing.T) {
 	workDir := path.Join(cwd, "funnel-work-dir")
 
 	fileConf := config.DefaultConfig()
-	tmp, cleanup := config.ToYamlTempFile(fileConf, "testconfig.yaml")
+	tmp, cleanup := util.TempConfigFile(fileConf, "testconfig.yaml")
 	defer cleanup()
 
 	c, h := newCommandHooks()

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ohsu-comp-bio/funnel/cmd/util"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/logger"
 )
@@ -15,7 +16,7 @@ func TestPersistentPreRun(t *testing.T) {
 	backend := "test-backend"
 
 	fileConf := config.DefaultConfig()
-	tmp, cleanup := config.ToYamlTempFile(fileConf, "testconfig.yaml")
+	tmp, cleanup := util.TempConfigFile(fileConf, "testconfig.yaml")
 	defer cleanup()
 
 	c, h := newCommandHooks()

--- a/cmd/util/config.go
+++ b/cmd/util/config.go
@@ -1,6 +1,10 @@
 package util
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/imdario/mergo"
 	"github.com/ohsu-comp-bio/funnel/config"
 )
@@ -24,4 +28,26 @@ func MergeConfigFileWithFlags(file string, flagConf config.Config) (config.Confi
 	}
 
 	return conf, nil
+}
+
+// TempConfigFile writes the configuration to a temporary file.
+// Returns:
+// - "path" is the path of the file.
+// - "cleanup" can be called to remove the temporary file.
+func TempConfigFile(c config.Config, name string) (path string, cleanup func()) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+
+	cleanup = func() {
+		os.RemoveAll(tmpdir)
+	}
+
+	p := filepath.Join(tmpdir, name)
+	err = config.ToYamlFile(c, p)
+	if err != nil {
+		panic(err)
+	}
+	return p, cleanup
 }

--- a/cmd/util/config_test.go
+++ b/cmd/util/config_test.go
@@ -32,7 +32,7 @@ func TestMergeConfigFileWithFlags(t *testing.T) {
 
 	fileConf := config.Config(defaultConf)
 	fileConf.Server.HTTPPort = "8888"
-	tmp, cleanup := config.ToYamlTempFile(fileConf, "testconfig.yaml")
+	tmp, cleanup := TempConfigFile(fileConf, "testconfig.yaml")
 	defer cleanup()
 	result, err = MergeConfigFileWithFlags(tmp, flagConf)
 	if err != nil {

--- a/cmd/worker/worker_test.go
+++ b/cmd/worker/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ohsu-comp-bio/funnel/cmd/util"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/logger"
 )
@@ -19,7 +20,7 @@ func TestPersistentPreRun(t *testing.T) {
 	workDir := path.Join(cwd, "funnel-work-dir")
 
 	fileConf := config.DefaultConfig()
-	tmp, cleanup := config.ToYamlTempFile(fileConf, "testconfig.yaml")
+	tmp, cleanup := util.TempConfigFile(fileConf, "testconfig.yaml")
 	defer cleanup()
 
 	c, h := newCommandHooks()

--- a/compute/hpc_backend.go
+++ b/compute/hpc_backend.go
@@ -225,7 +225,10 @@ func (b *HPCBackend) setupTemplatedHPCSubmit(task *tes.Task) (string, error) {
 	}
 
 	confPath := path.Join(workdir, "worker.conf.yml")
-	config.ToYamlFile(b.Conf, confPath)
+	err = config.ToYamlFile(b.Conf, confPath)
+	if err != nil {
+		return "", err
+	}
 
 	funnelPath, err := detectFunnelBinaryPath()
 	if err != nil {

--- a/config/utils.go
+++ b/config/utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -13,29 +12,17 @@ import (
 )
 
 // ToYaml formats the configuration into YAML and returns the bytes.
-func ToYaml(c Config) []byte {
-	// TODO handle error
-	yamlstr, _ := yaml.Marshal(c)
-	return yamlstr
+func ToYaml(c Config) ([]byte, error) {
+	return yaml.Marshal(c)
 }
 
 // ToYamlFile writes the configuration to a YAML file.
-func ToYamlFile(c Config, path string) {
-	// TODO handle error
-	ioutil.WriteFile(path, ToYaml(c), 0600)
-}
-
-// ToYamlTempFile writes the configuration to a YAML temp. file.
-func ToYamlTempFile(c Config, name string) (string, func()) {
-	tmpdir, _ := ioutil.TempDir("", "")
-
-	cleanup := func() {
-		os.RemoveAll(tmpdir)
+func ToYamlFile(c Config, path string) error {
+	b, err := ToYaml(c)
+	if err != nil {
+		return err
 	}
-
-	p := filepath.Join(tmpdir, name)
-	ToYamlFile(c, p)
-	return p, cleanup
+	return ioutil.WriteFile(path, b, 0600)
 }
 
 // Parse parses a YAML doc into the given Config instance.


### PR DESCRIPTION
Moved the temp file function to a util package, because it was only being used by tests.