### PR TITLE
cmd/task/create: read tasks from stdin

### DIFF
--- a/cmd/task/create.go
+++ b/cmd/task/create.go
@@ -14,14 +14,11 @@ import (
 // Create runs the "task create" CLI command, connecting to the server,
 // calling CreateTask, and writing output to the given writer.
 // Tasks are loaded from the "files" arg. "files" are file paths to JSON objects.
-func Create(server string, files []string, writer io.Writer) error {
+func Create(server string, files []string, reader io.Reader, writer io.Writer) error {
 	cli, err := tes.NewClient(server)
 	if err != nil {
 		return err
 	}
-
-	var reader io.Reader
-	reader = os.Stdin
 
 	for _, taskFile := range files {
 		f, err := os.Open(taskFile)

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -53,7 +53,6 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 	create := &cobra.Command{
 		Use:   "create [task.json ...]",
 		Short: "Create one or more tasks to run on the server.",
-		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return h.Create(tesServer, args, cmd.OutOrStdout())
 		},

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -53,8 +53,9 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 	create := &cobra.Command{
 		Use:   "create [task.json ...]",
 		Short: "Create one or more tasks to run on the server.",
+		Long:  `Tasks may be piped to stdin, e.g. "python generate_tasks.py | funnel task create"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return h.Create(tesServer, args, cmd.OutOrStdout())
+			return h.Create(tesServer, args, os.Stdin, cmd.OutOrStdout())
 		},
 	}
 
@@ -119,7 +120,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 }
 
 type hooks struct {
-	Create func(server string, messages []string, w io.Writer) error
+	Create func(server string, messages []string, r io.Reader, w io.Writer) error
 	Get    func(server string, ids []string, view string, w io.Writer) error
 	List   func(server, view, pageToken, stateFilter string, tagsFilter []string, pageSize uint32, all bool, w io.Writer) error
 	Cancel func(server string, ids []string, w io.Writer) error

--- a/cmd/task/task_test.go
+++ b/cmd/task/task_test.go
@@ -56,7 +56,7 @@ func TestList(t *testing.T) {
 func TestServerDefault(t *testing.T) {
 	cmd, h := newCommandHooks()
 
-	h.Create = func(server string, messages []string, w io.Writer) error {
+	h.Create = func(server string, messages []string, r io.Reader, w io.Writer) error {
 		if server != "http://localhost:8000" {
 			t.Errorf("expected localhost default, got '%s'", server)
 		}
@@ -110,7 +110,7 @@ func TestServerEnv(t *testing.T) {
 
 	cmd, h := newCommandHooks()
 
-	h.Create = func(server string, messages []string, w io.Writer) error {
+	h.Create = func(server string, messages []string, r io.Reader, w io.Writer) error {
 		if server != "foobar" {
 			t.Error("expected foobar")
 		}
@@ -164,7 +164,7 @@ func TestServerFlagOverride(t *testing.T) {
 
 	cmd, h := newCommandHooks()
 
-	h.Create = func(server string, messages []string, w io.Writer) error {
+	h.Create = func(server string, messages []string, r io.Reader, w io.Writer) error {
 		if server != "flagval" {
 			t.Error("expected flagval")
 		}

--- a/tests/cmd/hello-world.json
+++ b/tests/cmd/hello-world.json
@@ -1,0 +1,10 @@
+{
+  "name": "Hello world",
+  "description": "Demonstrates the most basic echo task.",
+  "executors": [
+    {
+      "image": "alpine",
+      "command": ["echo", "hello world"]
+    }
+  ]
+}

--- a/tests/cmd/task_create_test.go
+++ b/tests/cmd/task_create_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	taskCmd "github.com/ohsu-comp-bio/funnel/cmd/task"
+	"github.com/ohsu-comp-bio/funnel/tests"
+)
+
+func TestCreateStdin(t *testing.T) {
+	conf := tests.DefaultConfig()
+	conf.Compute = "noop"
+	fun := tests.NewFunnel(conf)
+	fun.StartServer()
+
+	a, _ := ioutil.ReadFile("hello-world.json")
+	b, _ := ioutil.ReadFile("hello-world.json")
+
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+	in.Write(a)
+	in.Write(b)
+
+	err := taskCmd.Create(conf.Server.HTTPAddress(), []string{"hello-world.json"}, in, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(ids) != 3 {
+		t.Fatal("err", ids)
+	}
+}


### PR DESCRIPTION
I have a script that generates many tasks. This feature allows me to pipe those tasks directly to funnel with `python generate-tasks.py | funnel task create -`. 

In the past I've written the extra code to write these tasks to a bunch of files in a directory, which is an annoying extra step when you're doing this frequently.

To do:
- [x] cli and website docs
- [x] tests