### PR TITLE
tes: force minimum 1 cpu

### DIFF
--- a/tes/utils.go
+++ b/tes/utils.go
@@ -48,6 +48,14 @@ func InitTask(task *Task) error {
 	task.Id = GenerateID()
 	task.State = Queued
 	task.CreationTime = time.Now().Format(time.RFC3339Nano)
+	if task.Resources == nil {
+		task.Resources = &Resources{
+			CpuCores: 1,
+		}
+	}
+	if task.Resources.CpuCores < 1 {
+		task.Resources.CpuCores = 1
+	}
 	if err := Validate(task); err != nil {
 		return fmt.Errorf("invalid task message:\n%s", err)
 	}


### PR DESCRIPTION
Closes #55 

This does give up the ability to request zero CPUs, but that's harder to achieve and this is a glaring issue that can cause servers to crash.

To do
- [ ] test