### PR TITLE
cmd/run: remove "extra" args

### DIFF
--- a/cmd/run/cmd_test.go
+++ b/cmd/run/cmd_test.go
@@ -16,7 +16,7 @@ func TestParse(t *testing.T) {
 
 	expected := []*tes.Task{
 		{
-			Name:        "foo",
+			Name:        "myname",
 			Description: "mydesc",
 			Inputs: []*tes.Input{
 				{
@@ -134,7 +134,6 @@ func TestParse(t *testing.T) {
     -e e1=e1v
     --env e2=e2v
     --stdout ./testdata/stdout-first
-    -x '--name foo'
     --exec 'echo two'
     --stdout ./testdata/stdout-second
     --vol /volone

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -178,6 +178,10 @@ func parseTaskArgs(vals *flagVals, args []string) {
 
 // Visit flags to determine commands + stdin/out/err
 // and build that information into vals.execs
+//
+// This is done so that multiple TES.Executors can be described by one
+// "funnel run" command line.
+// TODO possibly just remove this.
 func buildExecs(flags *pflag.FlagSet, vals *flagVals, args []string) {
 	vals.execs = nil
 	var exec *executor

--- a/cmd/run/usage.go
+++ b/cmd/run/usage.go
@@ -55,11 +55,6 @@ Examples:
   # Sleep for 5 seconds, and wait for the sleep to finish.
   funnel run 'sleep 5' --wait
 
-  # Reuse a set of arguments across multiple runs.
-  args='--wait --cpu 10 --ram 60 --disk 2000'
-  funnel run 'echo hello world" -x $args
-  funnel run 'echo hello world again" -x $args
-
   # Set environment variables
   funnel run 'echo $MSG' -e MSG=Hello
 

--- a/cmd/run/usage.go
+++ b/cmd/run/usage.go
@@ -13,8 +13,6 @@ General flags:
       --scatter     Scatter multiple tasks, one per row of the given file.
       --wait        Wait for the task to finish before exiting.
       --wait-for    Wait for the given task IDs before running the task.
-  -x, --extra       Parse funnel run arguments from the given string.
-  -X, --extra-file  Parse funnel run arguments from the given file.
 
 Input/output file flags:
   -i, --in          Input file e.g. varname=/path/to/input.txt


### PR DESCRIPTION
This code is complex and unused. 