### PR TITLE
build: use template for website download links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ git_upstream := $(shell git remote get-url $(shell git config branch.$(shell git
 export GIT_BRANCH = $(git_branch)
 export GIT_UPSTREAM = $(git_upstream)
 
+export FUNNEL_VERSION=0.7.0
+
 # Build the code
 install: depends
 	@touch version/version.go
@@ -206,14 +208,12 @@ full: proto install prune_deps add_deps tidy lint test website webdash
 
 # Build the website
 website:
-	@go get github.com/spf13/hugo
 	@cp ./config/*.txt ./website/static/funnel-config-examples/
 	@cp ./config/default-config.yaml ./website/static/funnel-config-examples/
 	hugo --source ./website
 
 # Serve the Funnel website on localhost:1313
 website-dev:
-	@go get github.com/spf13/hugo
 	@cp ./config/*.txt ./website/static/funnel-config-examples/
 	@cp ./config/default-config.yaml ./website/static/funnel-config-examples/
 	hugo --source ./website -w server

--- a/docs/docs/compute/aws-batch/index.html
+++ b/docs/docs/compute/aws-batch/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/compute/deployment/index.html
+++ b/docs/docs/compute/deployment/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/compute/grid-engine/index.html
+++ b/docs/docs/compute/grid-engine/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/compute/htcondor/index.html
+++ b/docs/docs/compute/htcondor/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/compute/index.html
+++ b/docs/docs/compute/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/compute/pbs-torque/index.html
+++ b/docs/docs/compute/pbs-torque/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/compute/slurm/index.html
+++ b/docs/docs/compute/slurm/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/databases/boltdb/index.html
+++ b/docs/docs/databases/boltdb/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/databases/datastore/index.html
+++ b/docs/docs/databases/datastore/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/databases/dynamodb/index.html
+++ b/docs/docs/databases/dynamodb/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/databases/elasticsearch/index.html
+++ b/docs/docs/databases/elasticsearch/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/databases/index.html
+++ b/docs/docs/databases/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/databases/mongodb/index.html
+++ b/docs/docs/databases/mongodb/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/development/developers/index.html
+++ b/docs/docs/development/developers/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/development/index.html
+++ b/docs/docs/development/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/events/index.html
+++ b/docs/docs/events/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/events/kafka/index.html
+++ b/docs/docs/events/kafka/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/security/basic/index.html
+++ b/docs/docs/security/basic/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/security/index.html
+++ b/docs/docs/security/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/storage/google-storage/index.html
+++ b/docs/docs/storage/google-storage/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/storage/http/index.html
+++ b/docs/docs/storage/http/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/storage/index.html
+++ b/docs/docs/storage/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/storage/local/index.html
+++ b/docs/docs/storage/local/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/storage/s3/index.html
+++ b/docs/docs/storage/s3/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/storage/swift/index.html
+++ b/docs/docs/storage/swift/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/docs/tasks/index.html
+++ b/docs/docs/tasks/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
@@ -299,13 +298,18 @@
   <div class="main col span_8_of_12">
     
 
-<h3 id="download">Download</h3>
+
+<h3>Download 0.7.0</h3>
+
 
 <ul>
-<li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-linux-amd64-0.7.0.tar.gz">linux <small>[funnel-linux-amd64-0.7.0.tar.gz]</small></a></li>
-<li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-darwin-amd64-0.7.0.tar.gz">mac <small>[funnel-darwin-amd64-0.7.0.tar.gz]</small></a></li>
-<li><small>Windows is not supported (yet), sorry!</small></li>
+  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-linux-amd64-0.7.0.tar.gz">linux</a></li>
+  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-darwin-amd64-0.7.0.tar.gz">mac</a></li>
+  <li><small>Windows is not supported (yet), sorry!</small></li>
 </ul>
+
+
+
 
 <p>Funnel is a single binary.<br />
 Funnel requires <a href="https://docker.io">Docker</a>.<br />

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="generator" content="Hugo 0.31-DEV" />
 
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -86,7 +86,7 @@ A node is a service which runs on each machine in a cluster. The node connects t
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://ohsu-comp-bio.github.io/funnel/download/</guid>
-      <description>Download  linux [funnel-linux-amd64-0.7.0.tar.gz] mac [funnel-darwin-amd64-0.7.0.tar.gz] Windows is not supported (yet), sorry!  Funnel is a single binary.
+      <description>Download 0.7.0  linux mac Windows is not supported (yet), sorry!  Funnel is a single binary.
 Funnel requires Docker.
 Funnel is beta quality. APIs might break, bugs exist, data might be lost.
 Homebrew brew tap ohsu-comp-bio/formula brew install funnel  Build the lastest development version optional In order to build the latest code, run:

--- a/website/content/download.md
+++ b/website/content/download.md
@@ -5,14 +5,7 @@ menu:
     weight: -2000
 ---
 
-### Download
-
-- [linux <small>[funnel-linux-amd64-0.7.0.tar.gz]</small>][linux-64-bin]
-- [mac <small>[funnel-darwin-amd64-0.7.0.tar.gz]</small>][mac-64-bin]
-- <small>Windows is not supported (yet), sorry!</small>
-
-[linux-64-bin]: https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-linux-amd64-0.7.0.tar.gz
-[mac-64-bin]: https://github.com/ohsu-comp-bio/funnel/releases/download/0.7.0/funnel-darwin-amd64-0.7.0.tar.gz
+{{< download-links >}}
 
 Funnel is a single binary.  
 Funnel requires [Docker][docker].  

--- a/website/layouts/partials/head.html
+++ b/website/layouts/partials/head.html
@@ -3,7 +3,6 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  {{ .Hugo.Generator }}
 
   <!-- Enable responsiveness on mobile devices-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/website/layouts/shortcodes/download-links.html
+++ b/website/layouts/shortcodes/download-links.html
@@ -1,0 +1,11 @@
+
+<h3>Download {{ getenv "FUNNEL_VERSION" }}</h3>
+
+
+<ul>
+  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/{{ getenv "FUNNEL_VERSION" }}/funnel-linux-amd64-{{ getenv "FUNNEL_VERSION" }}.tar.gz">linux</a></li>
+  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/{{ getenv "FUNNEL_VERSION" }}/funnel-darwin-amd64-{{ getenv "FUNNEL_VERSION" }}.tar.gz">mac</a></li>
+  <li><small>Windows is not supported (yet), sorry!</small></li>
+</ul>
+
+


### PR DESCRIPTION
This improves on #186 by moving the download link updates to a template, and the funnel version a Makefile variable, so there's no more editing of multiple places in the download page code.

Also, `go get github.com/spf13/hugo` is no longer supported, so I removed the `go get` command and expect the developer to have it installed.

Also, I removed the `<meta generator="hugo">` tag from the template, so that it doesn't clog up our diffs in the future.

Also, I made a minor tweak to the download link list, to remove the file name from the link. Now it just says "linux" or "mac"