### PR TITLE
Generated flags and env var support

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -31,6 +31,8 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		flagConf   config.Config
 	)
 
+	nodeFlags := cmdutil.ConfigFlags(&flagConf)
+
 	cmd := &cobra.Command{
 		Use:     "node",
 		Aliases: []string{"nodes"},
@@ -38,6 +40,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
+      cmdutil.LookupEnv(nodeFlags)
 			conf, err = cmdutil.MergeConfigFileWithFlags(configFile, flagConf)
 			if err != nil {
 				return fmt.Errorf("error processing config: %v", err)
@@ -47,7 +50,6 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		},
 	}
 
-	nodeFlags := cmdutil.ConfigFlags(&flagConf)
 	cmd.SetGlobalNormalizationFunc(cmdutil.NormalizeFlags)
 	f := cmd.PersistentFlags()
 	f.StringVarP(&configFile, "config", "c", configFile, "Config File")

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -40,7 +40,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-      cmdutil.LookupEnv(nodeFlags)
+			cmdutil.LookupEnv(nodeFlags)
 			conf, err = cmdutil.MergeConfigFileWithFlags(configFile, flagConf)
 			if err != nil {
 				return fmt.Errorf("error processing config: %v", err)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -47,9 +47,10 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		},
 	}
 
-	nodeFlags := cmdutil.NodeFlags(&flagConf, &configFile)
+	nodeFlags := cmdutil.ConfigFlags(&flagConf)
 	cmd.SetGlobalNormalizationFunc(cmdutil.NormalizeFlags)
 	f := cmd.PersistentFlags()
+	f.StringVarP(&configFile, "config", "c", configFile, "Config File")
 	f.AddFlagSet(nodeFlags)
 
 	run := &cobra.Command{

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -48,9 +48,10 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		},
 	}
 
-	serverFlags := cmdutil.ServerFlags(&flagConf, &configFile)
+	serverFlags := cmdutil.ConfigFlags(&flagConf)
 	cmd.SetGlobalNormalizationFunc(cmdutil.NormalizeFlags)
 	f := cmd.PersistentFlags()
+	f.StringVarP(&configFile, "config", "c", configFile, "Config File")
 	f.AddFlagSet(serverFlags)
 
 	run := &cobra.Command{

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -34,12 +34,15 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		flagConf   config.Config
 	)
 
+	serverFlags := cmdutil.ConfigFlags(&flagConf)
+
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "Funnel server commands.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
+      cmdutil.LookupEnv(serverFlags)
 			conf, err = cmdutil.MergeConfigFileWithFlags(configFile, flagConf)
 			if err != nil {
 				return fmt.Errorf("error processing config: %v", err)
@@ -48,7 +51,6 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		},
 	}
 
-	serverFlags := cmdutil.ConfigFlags(&flagConf)
 	cmd.SetGlobalNormalizationFunc(cmdutil.NormalizeFlags)
 	f := cmd.PersistentFlags()
 	f.StringVarP(&configFile, "config", "c", configFile, "Config File")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -42,7 +42,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-      cmdutil.LookupEnv(serverFlags)
+			cmdutil.LookupEnv(serverFlags)
 			conf, err = cmdutil.MergeConfigFileWithFlags(configFile, flagConf)
 			if err != nil {
 				return fmt.Errorf("error processing config: %v", err)

--- a/cmd/util/config.go
+++ b/cmd/util/config.go
@@ -4,10 +4,33 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/imdario/mergo"
 	"github.com/ohsu-comp-bio/funnel/config"
+	"github.com/spf13/pflag"
 )
+
+func normalize(name string) string {
+	from := []string{"-", "_"}
+	to := "."
+	for _, sep := range from {
+		name = strings.Replace(name, sep, to, -1)
+	}
+	return strings.ToLower(name)
+}
+
+// NormalizeFlags allows for flags to be case and separator insensitive.
+// Use it by passing it to cobra.Command.SetGlobalNormalizationFunc
+func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	lookup := map[string]string{"help": "help", normalize(name): name}
+
+	f.VisitAll(func(f *pflag.Flag) {
+		lookup[normalize(f.Name)] = f.Name
+	})
+
+	return pflag.NormalizedName(lookup[normalize(name)])
+}
 
 // MergeConfigFileWithFlags is a util used by server commands that use flags to set
 // Funnel config values. These commands can also take in the path to a Funnel config file.

--- a/cmd/util/config.go
+++ b/cmd/util/config.go
@@ -32,6 +32,33 @@ func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	return pflag.NormalizedName(lookup[normalize(name)])
 }
 
+// LookupEnv sets flag values based on environment variables.
+func LookupEnv(f *pflag.FlagSet) {
+  f.VisitAll(func(flag *pflag.Flag) {
+    // If the user set the value on the CLI, skip checking the environment.
+    // i.e. CLI flags override env vars.
+    if flag.Changed {
+      return
+    }
+
+    prefix := "Funnel_"
+    key := strings.Replace(flag.Name, ".", "_", -1)
+    // Give people flexibility, check a few variations of upper/lower case
+    keys := []string{
+      prefix + key,
+      strings.ToUpper(prefix + key),
+      strings.ToLower(prefix + key),
+    }
+
+    for _, k := range keys {
+      v, ok := os.LookupEnv(k)
+      if ok {
+        flag.Value.Set(v)
+      }
+    }
+  })
+}
+
 // MergeConfigFileWithFlags is a util used by server commands that use flags to set
 // Funnel config values. These commands can also take in the path to a Funnel config file.
 // This function ensures that the config gets set up properly. Flag values override values in

--- a/cmd/util/config.go
+++ b/cmd/util/config.go
@@ -34,29 +34,29 @@ func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 
 // LookupEnv sets flag values based on environment variables.
 func LookupEnv(f *pflag.FlagSet) {
-  f.VisitAll(func(flag *pflag.Flag) {
-    // If the user set the value on the CLI, skip checking the environment.
-    // i.e. CLI flags override env vars.
-    if flag.Changed {
-      return
-    }
+	f.VisitAll(func(flag *pflag.Flag) {
+		// If the user set the value on the CLI, skip checking the environment.
+		// i.e. CLI flags override env vars.
+		if flag.Changed {
+			return
+		}
 
-    prefix := "Funnel_"
-    key := strings.Replace(flag.Name, ".", "_", -1)
-    // Give people flexibility, check a few variations of upper/lower case
-    keys := []string{
-      prefix + key,
-      strings.ToUpper(prefix + key),
-      strings.ToLower(prefix + key),
-    }
+		prefix := "Funnel_"
+		key := strings.Replace(flag.Name, ".", "_", -1)
+		// Give people flexibility, check a few variations of upper/lower case
+		keys := []string{
+			prefix + key,
+			strings.ToUpper(prefix + key),
+			strings.ToLower(prefix + key),
+		}
 
-    for _, k := range keys {
-      v, ok := os.LookupEnv(k)
-      if ok {
-        flag.Value.Set(v)
-      }
-    }
-  })
+		for _, k := range keys {
+			v, ok := os.LookupEnv(k)
+			if ok {
+				flag.Value.Set(v)
+			}
+		}
+	})
 }
 
 // MergeConfigFileWithFlags is a util used by server commands that use flags to set

--- a/cmd/util/flags.go
+++ b/cmd/util/flags.go
@@ -8,29 +8,29 @@ import (
 func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 	f := pflag.NewFlagSet("", pflag.ContinueOnError)
 
-	f.StringSliceVar(&conf.EventWriters, "EventWriters", conf.EventWriters, "component selectors")
+	f.StringSliceVar(&conf.EventWriters, "EventWriters", conf.EventWriters, "Event systems to write to (kafka, pubsub, log, etc).")
 
-	f.StringVar(&conf.Database, "Database", conf.Database, "")
+	f.StringVar(&conf.Database, "Database", conf.Database, "Name of the database backend to use (mongodb, dynamodb, boltdb, etc).")
 
-	f.StringVar(&conf.Compute, "Compute", conf.Compute, "")
+	f.StringVar(&conf.Compute, "Compute", conf.Compute, "Name of the compute backend to use (manual, aws-batch, local, etc).")
 
-	f.StringVar(&conf.Server.ServiceName, "Server.ServiceName", conf.Server.ServiceName, "")
+	f.StringVar(&conf.Server.ServiceName, "Server.ServiceName", conf.Server.ServiceName, "Name of the service, used for metadata in the ServiceInfo endpoint.")
 
-	f.StringVar(&conf.Server.HostName, "Server.HostName", conf.Server.HostName, "")
+	f.StringVar(&conf.Server.HostName, "Server.HostName", conf.Server.HostName, "Host name of the server, used to create client connection addresses.")
 
-	f.StringVar(&conf.Server.HTTPPort, "Server.HTTPPort", conf.Server.HTTPPort, "")
+	f.StringVar(&conf.Server.HTTPPort, "Server.HTTPPort", conf.Server.HTTPPort, "Port to run the HTTP server on.")
 
-	f.StringVar(&conf.Server.RPCPort, "Server.RPCPort", conf.Server.RPCPort, "")
+	f.StringVar(&conf.Server.RPCPort, "Server.RPCPort", conf.Server.RPCPort, "Port to run the RPC server on.")
 
-	f.BoolVar(&conf.Server.DisableHTTPCache, "Server.DisableHTTPCache", conf.Server.DisableHTTPCache, "")
+	f.BoolVar(&conf.Server.DisableHTTPCache, "Server.DisableHTTPCache", conf.Server.DisableHTTPCache, "Disable the HTTP cache by sending no-cache headers in HTTP responses.")
 
-	f.StringVar(&conf.RPCClient.BasicCredential.User, "RPCClient.BasicCredential.User", conf.RPCClient.BasicCredential.User, "")
+	f.StringVar(&conf.RPCClient.BasicCredential.User, "RPCClient.BasicCredential.User", conf.RPCClient.BasicCredential.User, "User name")
 
-	f.StringVar(&conf.RPCClient.BasicCredential.Password, "RPCClient.BasicCredential.Password", conf.RPCClient.BasicCredential.Password, "")
+	f.StringVar(&conf.RPCClient.BasicCredential.Password, "RPCClient.BasicCredential.Password", conf.RPCClient.BasicCredential.Password, "Password")
 
-	f.StringVar(&conf.RPCClient.ServerAddress, "RPCClient.ServerAddress", conf.RPCClient.ServerAddress, "")
+	f.StringVar(&conf.RPCClient.ServerAddress, "RPCClient.ServerAddress", conf.RPCClient.ServerAddress, "Address of the RPC server.")
 
-	f.Var(&conf.RPCClient.Timeout, "RPCClient.Timeout", "The timeout to use for making RPC client connections in nanoseconds This timeout is Only enforced when used in conjunction with the grpc.WithBlock dial option.")
+	f.Var(&conf.RPCClient.Timeout, "RPCClient.Timeout", "The timeout to use for making RPC client connections in nanoseconds.")
 
 	f.UintVar(&conf.RPCClient.MaxRetries, "RPCClient.MaxRetries", conf.RPCClient.MaxRetries, "The maximum number of times that a request will be retried for failures.")
 
@@ -46,25 +46,25 @@ func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 
 	f.StringVar(&conf.Node.ID, "Node.ID", conf.Node.ID, "")
 
-	f.Uint32Var(&conf.Node.Resources.Cpus, "Node.Resources.Cpus", conf.Node.Resources.Cpus, "A Node will automatically try to detect what resources are available to it.")
+	f.Uint32Var(&conf.Node.Resources.Cpus, "Node.Resources.Cpus", conf.Node.Resources.Cpus, "Number of CPUs the node provides.")
 
-	f.Float64Var(&conf.Node.Resources.RamGb, "Node.Resources.RamGb", conf.Node.Resources.RamGb, "A Node will automatically try to detect what resources are available to it.")
+	f.Float64Var(&conf.Node.Resources.RamGb, "Node.Resources.RamGb", conf.Node.Resources.RamGb, "Amount of RAM (in gigabytes) the node provides.")
 
-	f.Float64Var(&conf.Node.Resources.DiskGb, "Node.Resources.DiskGb", conf.Node.Resources.DiskGb, "A Node will automatically try to detect what resources are available to it.")
+	f.Float64Var(&conf.Node.Resources.DiskGb, "Node.Resources.DiskGb", conf.Node.Resources.DiskGb, "Amount of disk space (in gigabytes) the node provides.")
 
-	f.Var(&conf.Node.Timeout, "Node.Timeout", "If the node has been idle for longer than the timeout, it will shut down.")
+	f.Var(&conf.Node.Timeout, "Node.Timeout", "Duration of time spent idle before the node will decide to shut down.")
 
 	f.Var(&conf.Node.UpdateRate, "Node.UpdateRate", "How often the node sends update requests to the server.")
 
-	f.StringVar(&conf.Worker.WorkDir, "Worker.WorkDir", conf.Worker.WorkDir, "Directory to write task files to")
+	f.StringVar(&conf.Worker.WorkDir, "Worker.WorkDir", conf.Worker.WorkDir, "Directory to write task files to.")
 
-	f.Var(&conf.Worker.PollingRate, "Worker.PollingRate", "How often the worker should poll for cancel signals")
+	f.Var(&conf.Worker.PollingRate, "Worker.PollingRate", "How often the worker should poll for cancel signals.")
 
 	f.Var(&conf.Worker.LogUpdateRate, "Worker.LogUpdateRate", "How often to update stdout/stderr log fields.")
 
 	f.Int64Var(&conf.Worker.LogTailSize, "Worker.LogTailSize", conf.Worker.LogTailSize, "Max bytes of stdout/stderr to store in the database.")
 
-	f.BoolVar(&conf.Worker.LeaveWorkDir, "Worker.LeaveWorkDir", conf.Worker.LeaveWorkDir, "Normally the worker cleans up its working directory after executing.")
+	f.BoolVar(&conf.Worker.LeaveWorkDir, "Worker.LeaveWorkDir", conf.Worker.LeaveWorkDir, "Disable working directory cleanup.")
 
 	f.StringVar(&conf.Logger.Level, "Logger.Level", conf.Logger.Level, "")
 
@@ -90,11 +90,11 @@ func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 
 	f.StringVar(&conf.Logger.TextFormat.Indent, "Logger.TextFormat.Indent", conf.Logger.TextFormat.Indent, "")
 
-	f.StringVar(&conf.BoltDB.Path, "BoltDB.Path", conf.BoltDB.Path, "")
+	f.StringVar(&conf.BoltDB.Path, "BoltDB.Path", conf.BoltDB.Path, "Path to the database file.")
 
-	f.StringVar(&conf.Badger.Path, "Badger.Path", conf.Badger.Path, "Path to database directory.")
+	f.StringVar(&conf.Badger.Path, "Badger.Path", conf.Badger.Path, "Path to the database directory.")
 
-	f.StringVar(&conf.DynamoDB.TableBasename, "DynamoDB.TableBasename", conf.DynamoDB.TableBasename, "")
+	f.StringVar(&conf.DynamoDB.TableBasename, "DynamoDB.TableBasename", conf.DynamoDB.TableBasename, "Basename to prefix all tables with.")
 
 	f.StringVar(&conf.DynamoDB.AWSConfig.Endpoint, "DynamoDB.AWSConfig.Endpoint", conf.DynamoDB.AWSConfig.Endpoint, "An optional endpoint URL (hostname only or fully qualified URI) that overrides the default generated endpoint for a client.")
 
@@ -106,33 +106,33 @@ func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 
 	f.StringVar(&conf.DynamoDB.AWSConfig.Secret, "DynamoDB.AWSConfig.Secret", conf.DynamoDB.AWSConfig.Secret, "")
 
-	f.StringVar(&conf.Elastic.IndexPrefix, "Elastic.IndexPrefix", conf.Elastic.IndexPrefix, "")
+	f.StringVar(&conf.Elastic.IndexPrefix, "Elastic.IndexPrefix", conf.Elastic.IndexPrefix, "Index prefix.")
 
-	f.StringVar(&conf.Elastic.URL, "Elastic.URL", conf.Elastic.URL, "")
+	f.StringVar(&conf.Elastic.URL, "Elastic.URL", conf.Elastic.URL, "URL of the Elasticsearch server.")
 
 	f.StringSliceVar(&conf.MongoDB.Addrs, "MongoDB.Addrs", conf.MongoDB.Addrs, "Addrs holds the addresses for the seed servers.")
 
 	f.StringVar(&conf.MongoDB.Database, "MongoDB.Database", conf.MongoDB.Database, "Database is the database name used within MongoDB to store funnel data.")
 
-	f.Var(&conf.MongoDB.Timeout, "MongoDB.Timeout", "Timeout is the amount of time to wait for a server to respond when first connecting and on follow up operations in the session.")
+	f.Var(&conf.MongoDB.Timeout, "MongoDB.Timeout", "Initial connection timeout.")
 
-	f.StringVar(&conf.MongoDB.Username, "MongoDB.Username", conf.MongoDB.Username, "Username and Password inform the credentials for the initial authentication done on the database defined by the Database field.")
+	f.StringVar(&conf.MongoDB.Username, "MongoDB.Username", conf.MongoDB.Username, "Username for authentication.")
 
-	f.StringVar(&conf.MongoDB.Password, "MongoDB.Password", conf.MongoDB.Password, "")
+	f.StringVar(&conf.MongoDB.Password, "MongoDB.Password", conf.MongoDB.Password, "Password for authentication.")
 
-	f.StringSliceVar(&conf.Kafka.Servers, "Kafka.Servers", conf.Kafka.Servers, "")
+	f.StringSliceVar(&conf.Kafka.Servers, "Kafka.Servers", conf.Kafka.Servers, "List of Kafka servers.")
 
-	f.StringVar(&conf.Kafka.Topic, "Kafka.Topic", conf.Kafka.Topic, "")
+	f.StringVar(&conf.Kafka.Topic, "Kafka.Topic", conf.Kafka.Topic, "Topic name to access.")
 
-	f.StringVar(&conf.PubSub.Topic, "PubSub.Topic", conf.PubSub.Topic, "")
+	f.StringVar(&conf.PubSub.Topic, "PubSub.Topic", conf.PubSub.Topic, "Topic name to access.")
 
-	f.StringVar(&conf.PubSub.Project, "PubSub.Project", conf.PubSub.Project, "")
+	f.StringVar(&conf.PubSub.Project, "PubSub.Project", conf.PubSub.Project, "Google project ID.")
 
-	f.StringVar(&conf.PubSub.CredentialsFile, "PubSub.CredentialsFile", conf.PubSub.CredentialsFile, "If no account file is provided then Funnel will try to use Google Application Default Credentials to authorize and authenticate the client.")
+	f.StringVar(&conf.PubSub.CredentialsFile, "PubSub.CredentialsFile", conf.PubSub.CredentialsFile, "Optional path to Google Cloud credentials file.")
 
-	f.StringVar(&conf.Datastore.Project, "Datastore.Project", conf.Datastore.Project, "")
+	f.StringVar(&conf.Datastore.Project, "Datastore.Project", conf.Datastore.Project, "Google Cloud project ID.")
 
-	f.StringVar(&conf.Datastore.CredentialsFile, "Datastore.CredentialsFile", conf.Datastore.CredentialsFile, "If no account file is provided then Funnel will try to use Google Application Default Credentials to authorize and authenticate the client.")
+	f.StringVar(&conf.Datastore.CredentialsFile, "Datastore.CredentialsFile", conf.Datastore.CredentialsFile, "Optional path to Google Cloud credentials file.")
 
 	f.BoolVar(&conf.HTCondor.DisableReconciler, "HTCondor.DisableReconciler", conf.HTCondor.DisableReconciler, "Turn off task state reconciler.")
 
@@ -152,7 +152,7 @@ func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 
 	f.StringVar(&conf.PBS.Template, "PBS.Template", conf.PBS.Template, "")
 
-	f.StringVar(&conf.GridEngine.Template, "GridEngine.Template", conf.GridEngine.Template, "")
+	f.StringVar(&conf.GridEngine.Template, "GridEngine.Template", conf.GridEngine.Template, "GridEngine submit template string.")
 
 	f.StringVar(&conf.AWSBatch.JobDefinition, "AWSBatch.JobDefinition", conf.AWSBatch.JobDefinition, "JobDefinition can be either a name or the Amazon Resource Name (ARN).")
 
@@ -172,11 +172,11 @@ func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 
 	f.StringVar(&conf.AWSBatch.AWSConfig.Secret, "AWSBatch.AWSConfig.Secret", conf.AWSBatch.AWSConfig.Secret, "")
 
-	f.BoolVar(&conf.LocalStorage.Disabled, "LocalStorage.Disabled", conf.LocalStorage.Disabled, "")
+	f.BoolVar(&conf.LocalStorage.Disabled, "LocalStorage.Disabled", conf.LocalStorage.Disabled, "Disables local storage access.")
 
-	f.StringSliceVar(&conf.LocalStorage.AllowedDirs, "LocalStorage.AllowedDirs", conf.LocalStorage.AllowedDirs, "")
+	f.StringSliceVar(&conf.LocalStorage.AllowedDirs, "LocalStorage.AllowedDirs", conf.LocalStorage.AllowedDirs, "List of directories which local storage is allowed to access.")
 
-	f.BoolVar(&conf.AmazonS3.Disabled, "AmazonS3.Disabled", conf.AmazonS3.Disabled, "")
+	f.BoolVar(&conf.AmazonS3.Disabled, "AmazonS3.Disabled", conf.AmazonS3.Disabled, "Disables Amazon S3 storage access.")
 
 	f.StringVar(&conf.AmazonS3.AWSConfig.Endpoint, "AmazonS3.AWSConfig.Endpoint", conf.AmazonS3.AWSConfig.Endpoint, "An optional endpoint URL (hostname only or fully qualified URI) that overrides the default generated endpoint for a client.")
 
@@ -188,31 +188,32 @@ func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 
 	f.StringVar(&conf.AmazonS3.AWSConfig.Secret, "AmazonS3.AWSConfig.Secret", conf.AmazonS3.AWSConfig.Secret, "")
 
-	f.BoolVar(&conf.GoogleStorage.Disabled, "GoogleStorage.Disabled", conf.GoogleStorage.Disabled, "")
+	f.BoolVar(&conf.GoogleStorage.Disabled, "GoogleStorage.Disabled", conf.GoogleStorage.Disabled, "Disables Google Cloud storage access.")
 
-	f.StringVar(&conf.GoogleStorage.CredentialsFile, "GoogleStorage.CredentialsFile", conf.GoogleStorage.CredentialsFile, "If no account file is provided then Funnel will try to use Google Application Default Credentials to authorize and authenticate the client.")
+	f.StringVar(&conf.GoogleStorage.CredentialsFile, "GoogleStorage.CredentialsFile", conf.GoogleStorage.CredentialsFile, "Optional path to Google Cloud credentials file.")
 
-	f.BoolVar(&conf.Swift.Disabled, "Swift.Disabled", conf.Swift.Disabled, "")
+	f.BoolVar(&conf.Swift.Disabled, "Swift.Disabled", conf.Swift.Disabled, "Disables Swift storage access.")
 
-	f.StringVar(&conf.Swift.UserName, "Swift.UserName", conf.Swift.UserName, "")
+	f.StringVar(&conf.Swift.UserName, "Swift.UserName", conf.Swift.UserName, "Username for authentication.")
 
-	f.StringVar(&conf.Swift.Password, "Swift.Password", conf.Swift.Password, "")
+	f.StringVar(&conf.Swift.Password, "Swift.Password", conf.Swift.Password, "Password for authentication.")
 
-	f.StringVar(&conf.Swift.AuthURL, "Swift.AuthURL", conf.Swift.AuthURL, "")
+	f.StringVar(&conf.Swift.AuthURL, "Swift.AuthURL", conf.Swift.AuthURL, "URL of the OpenStack/Swift auth service.")
 
-	f.StringVar(&conf.Swift.TenantName, "Swift.TenantName", conf.Swift.TenantName, "")
+	f.StringVar(&conf.Swift.TenantName, "Swift.TenantName", conf.Swift.TenantName, "Name of the OpenStack/Swift tenant.")
 
-	f.StringVar(&conf.Swift.TenantID, "Swift.TenantID", conf.Swift.TenantID, "")
+	f.StringVar(&conf.Swift.TenantID, "Swift.TenantID", conf.Swift.TenantID, "ID of the OpenStack/Swift tenant.")
 
-	f.StringVar(&conf.Swift.RegionName, "Swift.RegionName", conf.Swift.RegionName, "")
+	f.StringVar(&conf.Swift.RegionName, "Swift.RegionName", conf.Swift.RegionName, "Name of the OpenStack/Swift region.")
 
 	f.Int64Var(&conf.Swift.ChunkSizeBytes, "Swift.ChunkSizeBytes", conf.Swift.ChunkSizeBytes, "Size of chunks to use for large object creation.")
 
 	f.IntVar(&conf.Swift.MaxRetries, "Swift.MaxRetries", conf.Swift.MaxRetries, "The maximum number of times to retry on error.")
 
-	f.BoolVar(&conf.HTTPStorage.Disabled, "HTTPStorage.Disabled", conf.HTTPStorage.Disabled, "")
+	f.BoolVar(&conf.HTTPStorage.Disabled, "HTTPStorage.Disabled", conf.HTTPStorage.Disabled, "Disables HTTP storage access.")
 
-	f.Var(&conf.HTTPStorage.Timeout, "HTTPStorage.Timeout", "Timeout duration for http GET calls")
+	f.Var(&conf.HTTPStorage.Timeout, "HTTPStorage.Timeout", "Timeout duration for http GET calls.")
 
 	return f
 }
+

--- a/cmd/util/flags.go
+++ b/cmd/util/flags.go
@@ -216,4 +216,3 @@ func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 
 	return f
 }
-

--- a/cmd/util/flags.go
+++ b/cmd/util/flags.go
@@ -1,237 +1,218 @@
 package util
 
 import (
-	"strings"
-
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/spf13/pflag"
 )
 
-// ServerFlags returns a new flag set for configuring a Funnel server
-func ServerFlags(flagConf *config.Config, configFile *string) *pflag.FlagSet {
+func ConfigFlags(conf *config.Config) *pflag.FlagSet {
 	f := pflag.NewFlagSet("", pflag.ContinueOnError)
 
-	f.StringVarP(configFile, "config", "c", *configFile, "Config File")
+	f.StringSliceVar(&conf.EventWriters, "EventWriters", conf.EventWriters, "component selectors")
 
-	f.AddFlagSet(selectorFlags(flagConf))
-	f.AddFlagSet(serverFlags(flagConf))
-	f.AddFlagSet(rpcClientFlags(flagConf))
-	f.AddFlagSet(workerFlags(flagConf))
-	f.AddFlagSet(nodeFlags(flagConf))
-	f.AddFlagSet(dbFlags(flagConf))
-	f.AddFlagSet(storageFlags(flagConf))
-	f.AddFlagSet(computeFlags(flagConf))
-	f.AddFlagSet(loggerFlags(flagConf))
+	f.StringVar(&conf.Database, "Database", conf.Database, "")
+
+	f.StringVar(&conf.Compute, "Compute", conf.Compute, "")
+
+	f.StringVar(&conf.Server.ServiceName, "Server.ServiceName", conf.Server.ServiceName, "")
+
+	f.StringVar(&conf.Server.HostName, "Server.HostName", conf.Server.HostName, "")
+
+	f.StringVar(&conf.Server.HTTPPort, "Server.HTTPPort", conf.Server.HTTPPort, "")
+
+	f.StringVar(&conf.Server.RPCPort, "Server.RPCPort", conf.Server.RPCPort, "")
+
+	f.BoolVar(&conf.Server.DisableHTTPCache, "Server.DisableHTTPCache", conf.Server.DisableHTTPCache, "")
+
+	f.StringVar(&conf.RPCClient.BasicCredential.User, "RPCClient.BasicCredential.User", conf.RPCClient.BasicCredential.User, "")
+
+	f.StringVar(&conf.RPCClient.BasicCredential.Password, "RPCClient.BasicCredential.Password", conf.RPCClient.BasicCredential.Password, "")
+
+	f.StringVar(&conf.RPCClient.ServerAddress, "RPCClient.ServerAddress", conf.RPCClient.ServerAddress, "")
+
+	f.Var(&conf.RPCClient.Timeout, "RPCClient.Timeout", "The timeout to use for making RPC client connections in nanoseconds This timeout is Only enforced when used in conjunction with the grpc.WithBlock dial option.")
+
+	f.UintVar(&conf.RPCClient.MaxRetries, "RPCClient.MaxRetries", conf.RPCClient.MaxRetries, "The maximum number of times that a request will be retried for failures.")
+
+	f.Var(&conf.Scheduler.ScheduleRate, "Scheduler.ScheduleRate", "How often to run a scheduler iteration.")
+
+	f.IntVar(&conf.Scheduler.ScheduleChunk, "Scheduler.ScheduleChunk", conf.Scheduler.ScheduleChunk, "How many tasks to schedule in one iteration.")
+
+	f.Var(&conf.Scheduler.NodePingTimeout, "Scheduler.NodePingTimeout", "How long to wait for a node ping before marking it as dead")
+
+	f.Var(&conf.Scheduler.NodeInitTimeout, "Scheduler.NodeInitTimeout", "How long to wait for node initialization before marking it dead")
+
+	f.Var(&conf.Scheduler.NodeDeadTimeout, "Scheduler.NodeDeadTimeout", "How long to wait before deleting a dead node from the DB.")
+
+	f.StringVar(&conf.Node.ID, "Node.ID", conf.Node.ID, "")
+
+	f.Uint32Var(&conf.Node.Resources.Cpus, "Node.Resources.Cpus", conf.Node.Resources.Cpus, "A Node will automatically try to detect what resources are available to it.")
+
+	f.Float64Var(&conf.Node.Resources.RamGb, "Node.Resources.RamGb", conf.Node.Resources.RamGb, "A Node will automatically try to detect what resources are available to it.")
+
+	f.Float64Var(&conf.Node.Resources.DiskGb, "Node.Resources.DiskGb", conf.Node.Resources.DiskGb, "A Node will automatically try to detect what resources are available to it.")
+
+	f.Var(&conf.Node.Timeout, "Node.Timeout", "If the node has been idle for longer than the timeout, it will shut down.")
+
+	f.Var(&conf.Node.UpdateRate, "Node.UpdateRate", "How often the node sends update requests to the server.")
+
+	f.StringVar(&conf.Worker.WorkDir, "Worker.WorkDir", conf.Worker.WorkDir, "Directory to write task files to")
+
+	f.Var(&conf.Worker.PollingRate, "Worker.PollingRate", "How often the worker should poll for cancel signals")
+
+	f.Var(&conf.Worker.LogUpdateRate, "Worker.LogUpdateRate", "How often to update stdout/stderr log fields.")
+
+	f.Int64Var(&conf.Worker.LogTailSize, "Worker.LogTailSize", conf.Worker.LogTailSize, "Max bytes of stdout/stderr to store in the database.")
+
+	f.BoolVar(&conf.Worker.LeaveWorkDir, "Worker.LeaveWorkDir", conf.Worker.LeaveWorkDir, "Normally the worker cleans up its working directory after executing.")
+
+	f.StringVar(&conf.Logger.Level, "Logger.Level", conf.Logger.Level, "")
+
+	f.StringVar(&conf.Logger.Formatter, "Logger.Formatter", conf.Logger.Formatter, "")
+
+	f.StringVar(&conf.Logger.OutputFile, "Logger.OutputFile", conf.Logger.OutputFile, "")
+
+	f.BoolVar(&conf.Logger.JSONFormat.DisableTimestamp, "Logger.JSONFormat.DisableTimestamp", conf.Logger.JSONFormat.DisableTimestamp, "")
+
+	f.StringVar(&conf.Logger.JSONFormat.TimestampFormat, "Logger.JSONFormat.TimestampFormat", conf.Logger.JSONFormat.TimestampFormat, "")
+
+	f.BoolVar(&conf.Logger.TextFormat.ForceColors, "Logger.TextFormat.ForceColors", conf.Logger.TextFormat.ForceColors, "Set to true to bypass checking for a TTY before outputting colors.")
+
+	f.BoolVar(&conf.Logger.TextFormat.DisableColors, "Logger.TextFormat.DisableColors", conf.Logger.TextFormat.DisableColors, "Force disabling colors.")
+
+	f.BoolVar(&conf.Logger.TextFormat.DisableTimestamp, "Logger.TextFormat.DisableTimestamp", conf.Logger.TextFormat.DisableTimestamp, "Disable timestamp logging.")
+
+	f.BoolVar(&conf.Logger.TextFormat.FullTimestamp, "Logger.TextFormat.FullTimestamp", conf.Logger.TextFormat.FullTimestamp, "Enable logging the full timestamp when a TTY is attached instead of just the time passed since beginning of execution.")
+
+	f.StringVar(&conf.Logger.TextFormat.TimestampFormat, "Logger.TextFormat.TimestampFormat", conf.Logger.TextFormat.TimestampFormat, "TimestampFormat to use for display when a full timestamp is printed")
+
+	f.BoolVar(&conf.Logger.TextFormat.DisableSorting, "Logger.TextFormat.DisableSorting", conf.Logger.TextFormat.DisableSorting, "The fields are sorted by default for a consistent output.")
+
+	f.StringVar(&conf.Logger.TextFormat.Indent, "Logger.TextFormat.Indent", conf.Logger.TextFormat.Indent, "")
+
+	f.StringVar(&conf.BoltDB.Path, "BoltDB.Path", conf.BoltDB.Path, "")
+
+	f.StringVar(&conf.Badger.Path, "Badger.Path", conf.Badger.Path, "Path to database directory.")
+
+	f.StringVar(&conf.DynamoDB.TableBasename, "DynamoDB.TableBasename", conf.DynamoDB.TableBasename, "")
+
+	f.StringVar(&conf.DynamoDB.AWSConfig.Endpoint, "DynamoDB.AWSConfig.Endpoint", conf.DynamoDB.AWSConfig.Endpoint, "An optional endpoint URL (hostname only or fully qualified URI) that overrides the default generated endpoint for a client.")
+
+	f.StringVar(&conf.DynamoDB.AWSConfig.Region, "DynamoDB.AWSConfig.Region", conf.DynamoDB.AWSConfig.Region, "The region to send requests to.")
+
+	f.IntVar(&conf.DynamoDB.AWSConfig.MaxRetries, "DynamoDB.AWSConfig.MaxRetries", conf.DynamoDB.AWSConfig.MaxRetries, "The maximum number of times that a request will be retried for failures.")
+
+	f.StringVar(&conf.DynamoDB.AWSConfig.Key, "DynamoDB.AWSConfig.Key", conf.DynamoDB.AWSConfig.Key, "If both the key and secret are empty AWS credentials will be read from the environment.")
+
+	f.StringVar(&conf.DynamoDB.AWSConfig.Secret, "DynamoDB.AWSConfig.Secret", conf.DynamoDB.AWSConfig.Secret, "")
+
+	f.StringVar(&conf.Elastic.IndexPrefix, "Elastic.IndexPrefix", conf.Elastic.IndexPrefix, "")
+
+	f.StringVar(&conf.Elastic.URL, "Elastic.URL", conf.Elastic.URL, "")
+
+	f.StringSliceVar(&conf.MongoDB.Addrs, "MongoDB.Addrs", conf.MongoDB.Addrs, "Addrs holds the addresses for the seed servers.")
+
+	f.StringVar(&conf.MongoDB.Database, "MongoDB.Database", conf.MongoDB.Database, "Database is the database name used within MongoDB to store funnel data.")
+
+	f.Var(&conf.MongoDB.Timeout, "MongoDB.Timeout", "Timeout is the amount of time to wait for a server to respond when first connecting and on follow up operations in the session.")
+
+	f.StringVar(&conf.MongoDB.Username, "MongoDB.Username", conf.MongoDB.Username, "Username and Password inform the credentials for the initial authentication done on the database defined by the Database field.")
+
+	f.StringVar(&conf.MongoDB.Password, "MongoDB.Password", conf.MongoDB.Password, "")
+
+	f.StringSliceVar(&conf.Kafka.Servers, "Kafka.Servers", conf.Kafka.Servers, "")
+
+	f.StringVar(&conf.Kafka.Topic, "Kafka.Topic", conf.Kafka.Topic, "")
+
+	f.StringVar(&conf.PubSub.Topic, "PubSub.Topic", conf.PubSub.Topic, "")
+
+	f.StringVar(&conf.PubSub.Project, "PubSub.Project", conf.PubSub.Project, "")
+
+	f.StringVar(&conf.PubSub.CredentialsFile, "PubSub.CredentialsFile", conf.PubSub.CredentialsFile, "If no account file is provided then Funnel will try to use Google Application Default Credentials to authorize and authenticate the client.")
+
+	f.StringVar(&conf.Datastore.Project, "Datastore.Project", conf.Datastore.Project, "")
+
+	f.StringVar(&conf.Datastore.CredentialsFile, "Datastore.CredentialsFile", conf.Datastore.CredentialsFile, "If no account file is provided then Funnel will try to use Google Application Default Credentials to authorize and authenticate the client.")
+
+	f.BoolVar(&conf.HTCondor.DisableReconciler, "HTCondor.DisableReconciler", conf.HTCondor.DisableReconciler, "Turn off task state reconciler.")
+
+	f.Var(&conf.HTCondor.ReconcileRate, "HTCondor.ReconcileRate", "ReconcileRate is how often the compute backend compares states in Funnel's backend to those reported by the backend")
+
+	f.StringVar(&conf.HTCondor.Template, "HTCondor.Template", conf.HTCondor.Template, "")
+
+	f.BoolVar(&conf.Slurm.DisableReconciler, "Slurm.DisableReconciler", conf.Slurm.DisableReconciler, "Turn off task state reconciler.")
+
+	f.Var(&conf.Slurm.ReconcileRate, "Slurm.ReconcileRate", "ReconcileRate is how often the compute backend compares states in Funnel's backend to those reported by the backend")
+
+	f.StringVar(&conf.Slurm.Template, "Slurm.Template", conf.Slurm.Template, "")
+
+	f.BoolVar(&conf.PBS.DisableReconciler, "PBS.DisableReconciler", conf.PBS.DisableReconciler, "Turn off task state reconciler.")
+
+	f.Var(&conf.PBS.ReconcileRate, "PBS.ReconcileRate", "ReconcileRate is how often the compute backend compares states in Funnel's backend to those reported by the backend")
+
+	f.StringVar(&conf.PBS.Template, "PBS.Template", conf.PBS.Template, "")
+
+	f.StringVar(&conf.GridEngine.Template, "GridEngine.Template", conf.GridEngine.Template, "")
+
+	f.StringVar(&conf.AWSBatch.JobDefinition, "AWSBatch.JobDefinition", conf.AWSBatch.JobDefinition, "JobDefinition can be either a name or the Amazon Resource Name (ARN).")
+
+	f.StringVar(&conf.AWSBatch.JobQueue, "AWSBatch.JobQueue", conf.AWSBatch.JobQueue, "JobQueue can be either a name or the Amazon Resource Name (ARN).")
+
+	f.BoolVar(&conf.AWSBatch.DisableReconciler, "AWSBatch.DisableReconciler", conf.AWSBatch.DisableReconciler, "Turn off task state reconciler.")
+
+	f.Var(&conf.AWSBatch.ReconcileRate, "AWSBatch.ReconcileRate", "ReconcileRate is how often the compute backend compares states in Funnel's backend to those reported by AWS Batch")
+
+	f.StringVar(&conf.AWSBatch.AWSConfig.Endpoint, "AWSBatch.AWSConfig.Endpoint", conf.AWSBatch.AWSConfig.Endpoint, "An optional endpoint URL (hostname only or fully qualified URI) that overrides the default generated endpoint for a client.")
+
+	f.StringVar(&conf.AWSBatch.AWSConfig.Region, "AWSBatch.AWSConfig.Region", conf.AWSBatch.AWSConfig.Region, "The region to send requests to.")
+
+	f.IntVar(&conf.AWSBatch.AWSConfig.MaxRetries, "AWSBatch.AWSConfig.MaxRetries", conf.AWSBatch.AWSConfig.MaxRetries, "The maximum number of times that a request will be retried for failures.")
+
+	f.StringVar(&conf.AWSBatch.AWSConfig.Key, "AWSBatch.AWSConfig.Key", conf.AWSBatch.AWSConfig.Key, "If both the key and secret are empty AWS credentials will be read from the environment.")
+
+	f.StringVar(&conf.AWSBatch.AWSConfig.Secret, "AWSBatch.AWSConfig.Secret", conf.AWSBatch.AWSConfig.Secret, "")
+
+	f.BoolVar(&conf.LocalStorage.Disabled, "LocalStorage.Disabled", conf.LocalStorage.Disabled, "")
+
+	f.StringSliceVar(&conf.LocalStorage.AllowedDirs, "LocalStorage.AllowedDirs", conf.LocalStorage.AllowedDirs, "")
+
+	f.BoolVar(&conf.AmazonS3.Disabled, "AmazonS3.Disabled", conf.AmazonS3.Disabled, "")
+
+	f.StringVar(&conf.AmazonS3.AWSConfig.Endpoint, "AmazonS3.AWSConfig.Endpoint", conf.AmazonS3.AWSConfig.Endpoint, "An optional endpoint URL (hostname only or fully qualified URI) that overrides the default generated endpoint for a client.")
+
+	f.StringVar(&conf.AmazonS3.AWSConfig.Region, "AmazonS3.AWSConfig.Region", conf.AmazonS3.AWSConfig.Region, "The region to send requests to.")
+
+	f.IntVar(&conf.AmazonS3.AWSConfig.MaxRetries, "AmazonS3.AWSConfig.MaxRetries", conf.AmazonS3.AWSConfig.MaxRetries, "The maximum number of times that a request will be retried for failures.")
+
+	f.StringVar(&conf.AmazonS3.AWSConfig.Key, "AmazonS3.AWSConfig.Key", conf.AmazonS3.AWSConfig.Key, "If both the key and secret are empty AWS credentials will be read from the environment.")
+
+	f.StringVar(&conf.AmazonS3.AWSConfig.Secret, "AmazonS3.AWSConfig.Secret", conf.AmazonS3.AWSConfig.Secret, "")
+
+	f.BoolVar(&conf.GoogleStorage.Disabled, "GoogleStorage.Disabled", conf.GoogleStorage.Disabled, "")
+
+	f.StringVar(&conf.GoogleStorage.CredentialsFile, "GoogleStorage.CredentialsFile", conf.GoogleStorage.CredentialsFile, "If no account file is provided then Funnel will try to use Google Application Default Credentials to authorize and authenticate the client.")
+
+	f.BoolVar(&conf.Swift.Disabled, "Swift.Disabled", conf.Swift.Disabled, "")
+
+	f.StringVar(&conf.Swift.UserName, "Swift.UserName", conf.Swift.UserName, "")
+
+	f.StringVar(&conf.Swift.Password, "Swift.Password", conf.Swift.Password, "")
+
+	f.StringVar(&conf.Swift.AuthURL, "Swift.AuthURL", conf.Swift.AuthURL, "")
+
+	f.StringVar(&conf.Swift.TenantName, "Swift.TenantName", conf.Swift.TenantName, "")
+
+	f.StringVar(&conf.Swift.TenantID, "Swift.TenantID", conf.Swift.TenantID, "")
+
+	f.StringVar(&conf.Swift.RegionName, "Swift.RegionName", conf.Swift.RegionName, "")
+
+	f.Int64Var(&conf.Swift.ChunkSizeBytes, "Swift.ChunkSizeBytes", conf.Swift.ChunkSizeBytes, "Size of chunks to use for large object creation.")
+
+	f.IntVar(&conf.Swift.MaxRetries, "Swift.MaxRetries", conf.Swift.MaxRetries, "The maximum number of times to retry on error.")
+
+	f.BoolVar(&conf.HTTPStorage.Disabled, "HTTPStorage.Disabled", conf.HTTPStorage.Disabled, "")
+
+	f.Var(&conf.HTTPStorage.Timeout, "HTTPStorage.Timeout", "Timeout duration for http GET calls")
 
 	return f
-}
-
-// WorkerFlags returns a new flag set for configuring a Funnel worker
-func WorkerFlags(flagConf *config.Config, configFile *string) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.StringVarP(configFile, "config", "c", *configFile, "Config File")
-
-	f.AddFlagSet(selectorFlags(flagConf))
-	f.AddFlagSet(serverFlags(flagConf))
-	f.AddFlagSet(rpcClientFlags(flagConf))
-	f.AddFlagSet(workerFlags(flagConf))
-	f.AddFlagSet(nodeFlags(flagConf))
-	f.AddFlagSet(dbFlags(flagConf))
-	f.AddFlagSet(storageFlags(flagConf))
-	f.AddFlagSet(loggerFlags(flagConf))
-
-	return f
-}
-
-// NodeFlags returns a new flag set for configuring a Funnel node
-func NodeFlags(flagConf *config.Config, configFile *string) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.StringVarP(configFile, "config", "c", *configFile, "Config File")
-
-	f.AddFlagSet(selectorFlags(flagConf))
-	f.AddFlagSet(serverFlags(flagConf))
-	f.AddFlagSet(rpcClientFlags(flagConf))
-	f.AddFlagSet(workerFlags(flagConf))
-	f.AddFlagSet(nodeFlags(flagConf))
-	f.AddFlagSet(dbFlags(flagConf))
-	f.AddFlagSet(storageFlags(flagConf))
-	f.AddFlagSet(loggerFlags(flagConf))
-
-	return f
-}
-
-func selectorFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.StringVar(&flagConf.Compute, "Compute", flagConf.Compute, "Name of compute backed to use")
-	f.StringVar(&flagConf.Database, "Database", flagConf.Database, "Name of database backed to use")
-	f.StringSliceVar(&flagConf.EventWriters, "EventWriters", flagConf.EventWriters, "Name of an event writer backend to use. This flag can be used multiple times")
-
-	return f
-}
-
-func rpcClientFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.StringVar(&flagConf.RPCClient.ServerAddress, "RPCClient.ServerAddress", flagConf.RPCClient.ServerAddress, "RPC server address")
-	f.Var(&flagConf.RPCClient.Timeout, "RPCClient.Timeout", "Request timeout for RPC client connections")
-	f.UintVar(&flagConf.RPCClient.MaxRetries, "RPCClient.MaxRetries", flagConf.RPCClient.MaxRetries, "Maximum number of times that a request will be retried for failures")
-
-	return f
-}
-
-func serverFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.StringVar(&flagConf.Server.HostName, "Server.HostName", flagConf.Server.HostName, "Host name or IP")
-	f.StringVar(&flagConf.Server.HTTPPort, "Server.HTTPPort", flagConf.Server.HTTPPort, "HTTP Port")
-	f.StringVar(&flagConf.Server.RPCPort, "Server.RPCPort", flagConf.Server.RPCPort, "RPC Port")
-	f.StringVar(&flagConf.Server.ServiceName, "Server.ServiceName", flagConf.Server.ServiceName, "Host name or IP")
-
-	return f
-}
-
-func workerFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.Int64Var(&flagConf.Worker.LogTailSize, "Worker.LogTailSize", flagConf.Worker.LogTailSize, "Max bytes to store for stdout/stderr")
-	f.Var(&flagConf.Worker.LogUpdateRate, "Worker.LogUpdateRate", "How often to send stdout/stderr log updates")
-	f.Var(&flagConf.Worker.PollingRate, "Worker.PollingRate", "How often to poll for cancel signals")
-	f.StringVar(&flagConf.Worker.WorkDir, "Worker.WorkDir", flagConf.Worker.WorkDir, "Working directory")
-	f.BoolVar(&flagConf.Worker.LeaveWorkDir, "Worker.LeaveWorkDir", flagConf.Worker.LeaveWorkDir, "Leave working directory after execution")
-
-	return f
-}
-
-func nodeFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.Uint32Var(&flagConf.Node.Resources.Cpus, "Node.Resources.Cpus", flagConf.Node.Resources.Cpus, "Cpus available to Node")
-	f.Float64Var(&flagConf.Node.Resources.RamGb, "Node.Resources.RamGb", flagConf.Node.Resources.RamGb, "Ram (GB) available to Node")
-	f.Float64Var(&flagConf.Node.Resources.DiskGb, "Node.Resources.DiskGb", flagConf.Node.Resources.DiskGb, "Free disk (GB) available to Node")
-	f.Var(&flagConf.Node.Timeout, "Node.Timeout", "Node timeout in seconds")
-	f.Var(&flagConf.Node.UpdateRate, "Node.UpdateRate", "Node update rate")
-	// TODO Metadata
-
-	return f
-}
-
-func loggerFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	f.StringVar(&flagConf.Logger.Level, "Logger.Level", flagConf.Logger.Level, "Level of logging")
-	f.StringVar(&flagConf.Logger.OutputFile, "Logger.OutputFile", flagConf.Logger.OutputFile, "File path to write logs to")
-	f.StringVar(&flagConf.Logger.Formatter, "Logger.Formatter", flagConf.Logger.Formatter, "Logs formatter. One of ['text', 'json']")
-
-	return f
-}
-
-func dbFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	// boltdb
-	f.StringVar(&flagConf.BoltDB.Path, "BoltDB.Path", flagConf.BoltDB.Path, "Path to BoltDB database")
-
-	// dynamodb
-	f.StringVar(&flagConf.DynamoDB.Region, "DynamoDB.Region", flagConf.DynamoDB.Region, "AWS region of DynamoDB tables")
-	f.StringVar(&flagConf.DynamoDB.TableBasename, "DynamoDB.TableBasename", flagConf.DynamoDB.TableBasename, "Basename of DynamoDB tables")
-	f.IntVar(&flagConf.DynamoDB.MaxRetries, "DynamoDB.MaxRetries", flagConf.DynamoDB.MaxRetries, "Maximum number of times that a request will be retried for failures")
-
-	// datastore
-	f.StringVar(&flagConf.Datastore.Project, "Datastore.Project", flagConf.Datastore.Project, "Google project for Datastore")
-
-	// elastic
-	f.StringVar(&flagConf.Elastic.IndexPrefix, "Elastic.IndexPrefix", flagConf.Elastic.IndexPrefix, "Prefix to use for Elasticsearch indices")
-	f.StringVar(&flagConf.Elastic.URL, "Elastic.URL", flagConf.Elastic.URL, "Elasticsearch URL")
-
-	// kafka
-	f.StringSliceVar(&flagConf.Kafka.Servers, "Kafka.Servers", flagConf.Kafka.Servers, "Address of a Kafka server. This flag can be used multiple times")
-	f.StringVar(&flagConf.Kafka.Topic, "Kafka.Topic", flagConf.Kafka.Topic, "Kafka topic to write events to")
-
-	// mongodb
-	f.StringSliceVar(&flagConf.MongoDB.Addrs, "MongoDB.Addrs", flagConf.MongoDB.Addrs, "Address of a MongoDB seed server. This flag can be used multiple times")
-	f.StringVar(&flagConf.MongoDB.Database, "MongoDB.Database", flagConf.MongoDB.Database, "Database name in MongoDB")
-	f.Var(&flagConf.MongoDB.Timeout, "MongoDB.Timeout", "Timeout in seconds for initial connection and follow up operations")
-
-	return f
-}
-
-func storageFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	// local storage
-	f.BoolVar(&flagConf.LocalStorage.Disabled, "LocalStorage.Disabled", flagConf.LocalStorage.Disabled, "Disable storage backend")
-	f.StringSliceVar(&flagConf.LocalStorage.AllowedDirs, "LocalStorage.AllowedDirs", flagConf.LocalStorage.AllowedDirs, "Directories Funnel is allowed to access. This flag can be used multiple times")
-
-	// amazon s3
-	f.BoolVar(&flagConf.AmazonS3.Disabled, "AmazonS3.Disabled", flagConf.AmazonS3.Disabled, "Disable storage backend")
-	f.IntVar(&flagConf.AmazonS3.MaxRetries, "AmazonS3.MaxRetries", flagConf.AmazonS3.MaxRetries, "Maximum number of times that a request will be retried for failures")
-
-	// google storage
-	f.BoolVar(&flagConf.GoogleStorage.Disabled, "GoogleStorage.Disabled", flagConf.GoogleStorage.Disabled, "Disable storage backend")
-
-	// swift
-	f.BoolVar(&flagConf.Swift.Disabled, "Swift.Disabled", flagConf.Swift.Disabled, "Disable storage backend")
-	f.Int64Var(&flagConf.Swift.ChunkSizeBytes, "Swift.ChunkSizeBytes", flagConf.Swift.ChunkSizeBytes, "Size of chunks to use for large object creation")
-	f.IntVar(&flagConf.Swift.MaxRetries, "Swift.MaxRetries", flagConf.Swift.MaxRetries, "Maximum number of times that a request will be retried for failures")
-
-	// HTTP storage
-	f.BoolVar(&flagConf.HTTPStorage.Disabled, "HTTPStorage.Disabled", flagConf.HTTPStorage.Disabled, "Disable storage backend")
-	f.Var(&flagConf.HTTPStorage.Timeout, "HTTPStorage.Timeout", "Timeout in seconds for request")
-
-	return f
-}
-
-func computeFlags(flagConf *config.Config) *pflag.FlagSet {
-	f := pflag.NewFlagSet("", pflag.ContinueOnError)
-
-	// AWS Batch
-	f.StringVar(&flagConf.AWSBatch.Region, "AWSBatch.Region", flagConf.AWSBatch.Region, "AWS region of Batch resources")
-	f.StringVar(&flagConf.AWSBatch.JobDefinition, "AWSBatch.JobDefinition", flagConf.AWSBatch.JobDefinition, "AWS Batch job definition name or ARN")
-	f.StringVar(&flagConf.AWSBatch.JobQueue, "AWSBatch.JobQueue", flagConf.AWSBatch.JobQueue, "AWS Batch job queue name or ARN")
-	f.IntVar(&flagConf.AWSBatch.MaxRetries, "AWSBatch.MaxRetries", flagConf.AWSBatch.MaxRetries, "Maximum number of times that a request will be retried for failures")
-
-	// GridEngine
-	f.StringVar(&flagConf.GridEngine.Template, "GridEngine.Template", flagConf.GridEngine.Template, "Path to submit template file")
-
-	// HTCondor
-	f.StringVar(&flagConf.HTCondor.Template, "HTCondor.Template", flagConf.HTCondor.Template, "Path to submit template file")
-
-	// PBS/Torque
-	f.StringVar(&flagConf.PBS.Template, "PBS.Template", flagConf.PBS.Template, "Path to submit template file")
-
-	// Scheduler
-	f.Var(&flagConf.Scheduler.ScheduleRate, "Scheduler.ScheduleRate", "How often to run a scheduler iteration")
-	f.IntVar(&flagConf.Scheduler.ScheduleChunk, "Scheduler.ScheduleChunk", flagConf.Scheduler.ScheduleChunk, "How many tasks to schedule in one iteration")
-	f.Var(&flagConf.Scheduler.NodePingTimeout, "Scheduler.NodePingTimeout", "How long to wait for a node ping before marking it as dead")
-	f.Var(&flagConf.Scheduler.NodeInitTimeout, "Scheduler.NodeInitTimeout", "How long to wait for node initialization before marking it dead")
-	f.Var(&flagConf.Scheduler.NodeDeadTimeout, "Scheduler.NodeDeadTimeout", "How long to wait before deleting a dead node from the DB")
-
-	// Slurm
-	f.StringVar(&flagConf.Slurm.Template, "Slurm.Template", flagConf.Slurm.Template, "Path to submit template file")
-
-	return f
-}
-
-func normalize(name string) string {
-	from := []string{"-", "_"}
-	to := "."
-	for _, sep := range from {
-		name = strings.Replace(name, sep, to, -1)
-	}
-	return strings.ToLower(name)
-}
-
-// NormalizeFlags allows for flags to be case and separator insensitive.
-// Use it by passing it to cobra.Command.SetGlobalNormalizationFunc
-func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
-	lookup := map[string]string{"help": "help", normalize(name): name}
-
-	f.VisitAll(func(f *pflag.Flag) {
-		lookup[normalize(f.Name)] = f.Name
-	})
-
-	return pflag.NormalizedName(lookup[normalize(name)])
 }

--- a/cmd/util/flags.tpl
+++ b/cmd/util/flags.tpl
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"github.com/spf13/pflag"
+  "github.com/ohsu-comp-bio/funnel/config"
+)
+
+func ConfigFlags(conf *config.Config) *pflag.FlagSet {
+	f := pflag.NewFlagSet("", pflag.ContinueOnError)
+
+  {{ range .Leaves -}}
+    {{ if .IsValueType }}
+      f.Var(&conf.{{ join .Key }}, "{{ join .Key }}", "{{ synopsis .Doc }}")
+    {{ else }}
+      f.{{ pflagType . }}Var(&conf.{{ join .Key }}, "{{ join .Key }}", conf.{{ join .Key }}, "{{ synopsis .Doc }}")
+    {{ end }}
+  {{ end }}
+
+  return f
+}

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -49,9 +49,10 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 			return nil
 		},
 	}
-	workerFlags := cmdutil.WorkerFlags(&flagConf, &configFile)
+	workerFlags := cmdutil.ConfigFlags(&flagConf)
 	cmd.SetGlobalNormalizationFunc(cmdutil.NormalizeFlags)
 	f := cmd.PersistentFlags()
+	f.StringVarP(&configFile, "config", "c", configFile, "Config File")
 	f.AddFlagSet(workerFlags)
 
 	run := &cobra.Command{

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -34,6 +34,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		flagConf   config.Config
 		taskID     string
 	)
+	workerFlags := cmdutil.ConfigFlags(&flagConf)
 
 	cmd := &cobra.Command{
 		Use:   "worker",
@@ -41,6 +42,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
+      cmdutil.LookupEnv(workerFlags)
 			conf, err = cmdutil.MergeConfigFileWithFlags(configFile, flagConf)
 			if err != nil {
 				return fmt.Errorf("error processing config: %v", err)
@@ -49,7 +51,6 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 			return nil
 		},
 	}
-	workerFlags := cmdutil.ConfigFlags(&flagConf)
 	cmd.SetGlobalNormalizationFunc(cmdutil.NormalizeFlags)
 	f := cmd.PersistentFlags()
 	f.StringVarP(&configFile, "config", "c", configFile, "Config File")

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -42,7 +42,7 @@ func newCommandHooks() (*cobra.Command, *hooks) {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-      cmdutil.LookupEnv(workerFlags)
+			cmdutil.LookupEnv(workerFlags)
 			conf, err = cmdutil.MergeConfigFileWithFlags(configFile, flagConf)
 			if err != nil {
 				return fmt.Errorf("error processing config: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -9,14 +9,14 @@ import (
 
 // Config describes configuration for Funnel.
 type Config struct {
-  // Event systems to write to (kafka, pubsub, log, etc).
+	// Event systems to write to (kafka, pubsub, log, etc).
 	EventWriters []string
-  // Name of the database backend to use (mongodb, dynamodb, boltdb, etc).
-	Database     string
-  // Name of the compute backend to use (manual, aws-batch, local, etc).
-	Compute      string
+	// Name of the database backend to use (mongodb, dynamodb, boltdb, etc).
+	Database string
+	// Name of the compute backend to use (manual, aws-batch, local, etc).
+	Compute string
 
-  // core services
+	// core services
 	Server    Server
 	RPCClient RPCClient
 	Scheduler Scheduler
@@ -39,7 +39,7 @@ type Config struct {
 	Slurm      HPCBackend
 	PBS        HPCBackend
 	GridEngine struct {
-    // GridEngine submit template string.
+		// GridEngine submit template string.
 		Template string
 	}
 	AWSBatch AWSBatch
@@ -55,24 +55,24 @@ type Config struct {
 
 // BasicCredential describes a username and password for use with Funnel's basic auth.
 type BasicCredential struct {
-  // User name
-	User     string
-  // Password
+	// User name
+	User string
+	// Password
 	Password string
 }
 
 // RPCClient describes configuration for gRPC clients
 type RPCClient struct {
 	BasicCredential
-  // Address of the RPC server.
+	// Address of the RPC server.
 	ServerAddress string
 	// The timeout to use for making RPC client connections in nanoseconds.
-  //
+	//
 	// This timeout is Only enforced when used in conjunction with the
 	// grpc.WithBlock dial option.
 	Timeout Duration
 	// The maximum number of times that a request will be retried for failures.
-  //
+	//
 	// Time between retries follows an exponential backoff starting at 5 seconds,
 	// up to 1 minute.
 	MaxRetries uint
@@ -80,17 +80,17 @@ type RPCClient struct {
 
 // Server describes configuration for the server.
 type Server struct {
-  // Name of the service, used for metadata in the ServiceInfo endpoint.
-	ServiceName      string
-  // Host name of the server, used to create client connection addresses.
-	HostName         string
-  // Port to run the HTTP server on.
-	HTTPPort         string
-  // Port to run the RPC server on.
-	RPCPort          string
-  // Basic auth credentials (http basic user/password).
-	BasicAuth        []BasicCredential
-  // Disable the HTTP cache by sending no-cache headers in HTTP responses.
+	// Name of the service, used for metadata in the ServiceInfo endpoint.
+	ServiceName string
+	// Host name of the server, used to create client connection addresses.
+	HostName string
+	// Port to run the HTTP server on.
+	HTTPPort string
+	// Port to run the RPC server on.
+	RPCPort string
+	// Basic auth credentials (http basic user/password).
+	BasicAuth []BasicCredential
+	// Disable the HTTP cache by sending no-cache headers in HTTP responses.
 	DisableHTTPCache bool
 }
 
@@ -136,15 +136,15 @@ type Node struct {
 	// A Node will automatically try to detect what resources are available to it.
 	// Defining Resources in the Node configuration overrides this behavior.
 	Resources struct {
-    // Number of CPUs the node provides.
-		Cpus   uint32
-    // Amount of RAM (in gigabytes) the node provides.
-		RamGb  float64 // nolint
-    // Amount of disk space (in gigabytes) the node provides.
+		// Number of CPUs the node provides.
+		Cpus uint32
+		// Amount of RAM (in gigabytes) the node provides.
+		RamGb float64 // nolint
+		// Amount of disk space (in gigabytes) the node provides.
 		DiskGb float64
 	}
-  // Duration of time spent idle before the node will decide to shut down.
-  //
+	// Duration of time spent idle before the node will decide to shut down.
+	//
 	// If the node has been idle for longer than the timeout, it will shut down.
 	// -1 means there is no timeout. 0 means timeout immediately after the first task.
 	Timeout Duration
@@ -166,8 +166,8 @@ type Worker struct {
 	// Max bytes of stdout/stderr to store in the database.
 	// Setting this to 0 turns off stdout/stderr logging.
 	LogTailSize int64
-  // Disable working directory cleanup.
-  //
+	// Disable working directory cleanup.
+	//
 	// Normally the worker cleans up its working directory after executing.
 	// This option disables that behavior.
 	LeaveWorkDir bool
@@ -188,7 +188,7 @@ type HPCBackend struct {
 
 // BoltDB describes the configuration for the BoltDB embedded database.
 type BoltDB struct {
-  // Path to the database file.
+	// Path to the database file.
 	Path string
 }
 
@@ -204,46 +204,46 @@ type MongoDB struct {
 	Addrs []string
 	// Database is the database name used within MongoDB to store funnel data.
 	Database string
-  // Initial connection timeout.
-  //
+	// Initial connection timeout.
+	//
 	// Timeout is the amount of time to wait for a server to respond when
 	// first connecting and on follow up operations in the session. If
 	// timeout is zero, the call may block forever waiting for a connection
 	// to be established.
 	Timeout Duration
-  // Username for authentication.
-  //
+	// Username for authentication.
+	//
 	// Username and Password inform the credentials for the initial authentication
 	// done on the database defined by the Database field.
 	Username string
-  // Password for authentication.
+	// Password for authentication.
 	Password string
 }
 
 // Elastic configures access to an Elasticsearch database.
 type Elastic struct {
-  // Index prefix.
+	// Index prefix.
 	IndexPrefix string
-  // URL of the Elasticsearch server.
-	URL         string
+	// URL of the Elasticsearch server.
+	URL string
 }
 
 // Kafka configure access to a Kafka topic for task event reading/writing.
 type Kafka struct {
-  // List of Kafka servers.
+	// List of Kafka servers.
 	Servers []string
-  // Topic name to access.
-	Topic   string
+	// Topic name to access.
+	Topic string
 }
 
 // PubSub configures access to Google Cloud Pub/Sub for task event reading/writing.
 type PubSub struct {
-  // Topic name to access.
-	Topic   string
-  // Google project ID.
+	// Topic name to access.
+	Topic string
+	// Google project ID.
 	Project string
-  // Optional path to Google Cloud credentials file.
-  //
+	// Optional path to Google Cloud credentials file.
+	//
 	// If no account file is provided then Funnel will try to use Google Application
 	// Default Credentials to authorize and authenticate the client.
 	CredentialsFile string
@@ -285,10 +285,10 @@ type AWSBatch struct {
 
 // Datastore configures access to a Google Cloud Datastore database backend.
 type Datastore struct {
-  // Google Cloud project ID.
+	// Google Cloud project ID.
 	Project string
-  // Optional path to Google Cloud credentials file.
-  //
+	// Optional path to Google Cloud credentials file.
+	//
 	// If no account file is provided then Funnel will try to use Google Application
 	// Default Credentials to authorize and authenticate the client.
 	CredentialsFile string
@@ -297,16 +297,16 @@ type Datastore struct {
 // DynamoDB describes the configuration for Amazon DynamoDB backed processes
 // such as the event writer and server.
 type DynamoDB struct {
-  // Basename to prefix all tables with.
+	// Basename to prefix all tables with.
 	TableBasename string
 	AWSConfig
 }
 
 // LocalStorage describes the directories Funnel can read from and write to
 type LocalStorage struct {
-  // Disables local storage access.
-	Disabled    bool
-  // List of directories which local storage is allowed to access.
+	// Disables local storage access.
+	Disabled bool
+	// List of directories which local storage is allowed to access.
 	AllowedDirs []string
 }
 
@@ -317,10 +317,10 @@ func (l LocalStorage) Valid() bool {
 
 // GoogleCloudStorage describes configuration for the Google Cloud storage backend.
 type GoogleCloudStorage struct {
-  // Disables Google Cloud storage access.
+	// Disables Google Cloud storage access.
 	Disabled bool
-  // Optional path to Google Cloud credentials file.
-  //
+	// Optional path to Google Cloud credentials file.
+	//
 	// If no account file is provided then Funnel will try to use Google Application
 	// Default Credentials to authorize and authenticate the client.
 	CredentialsFile string
@@ -333,7 +333,7 @@ func (g GoogleCloudStorage) Valid() bool {
 
 // AmazonS3Storage describes the configuration for the Amazon S3 storage backend.
 type AmazonS3Storage struct {
-  // Disables Amazon S3 storage access.
+	// Disables Amazon S3 storage access.
 	Disabled bool
 	AWSConfig
 }
@@ -346,14 +346,14 @@ func (s AmazonS3Storage) Valid() bool {
 
 // GenericS3Storage describes the configuration for the Generic S3 storage backend.
 type GenericS3Storage struct {
-  // Disables generic S3 storage access.
+	// Disables generic S3 storage access.
 	Disabled bool
-  // Endpoint of the S3 storage service.
+	// Endpoint of the S3 storage service.
 	Endpoint string
-  // Key for authentication.
-	Key      string
-  // Secret for authentication.
-	Secret   string
+	// Key for authentication.
+	Key string
+	// Secret for authentication.
+	Secret string
 }
 
 // Valid validates the S3Storage configuration
@@ -363,22 +363,22 @@ func (s GenericS3Storage) Valid() bool {
 
 // SwiftStorage configures the OpenStack Swift object storage backend.
 type SwiftStorage struct {
-  // Disables Swift storage access.
-	Disabled   bool
-  // Username for authentication.
-	UserName   string
-  // Password for authentication.
-	Password   string
-  // URL of the OpenStack/Swift auth service.
-	AuthURL    string
-  // Name of the OpenStack/Swift tenant.
+	// Disables Swift storage access.
+	Disabled bool
+	// Username for authentication.
+	UserName string
+	// Password for authentication.
+	Password string
+	// URL of the OpenStack/Swift auth service.
+	AuthURL string
+	// Name of the OpenStack/Swift tenant.
 	TenantName string
-  // ID of the OpenStack/Swift tenant.
-	TenantID   string
-  // Name of the OpenStack/Swift region.
+	// ID of the OpenStack/Swift tenant.
+	TenantID string
+	// Name of the OpenStack/Swift region.
 	RegionName string
 	// Size of chunks to use for large object creation.
-  //
+	//
 	// Defaults to 500 MB if not set or set below 10 MB.
 	// The max number of chunks for a single object is 1000.
 	ChunkSizeBytes int64
@@ -402,7 +402,7 @@ func (s SwiftStorage) Valid() bool {
 
 // HTTPStorage configures the http storage backend.
 type HTTPStorage struct {
-  // Disables HTTP storage access.
+	// Disables HTTP storage access.
 	Disabled bool
 	// Timeout duration for http GET calls.
 	Timeout Duration


### PR DESCRIPTION
This needs a little more work, but want to get some feedback.

github.com/buchanae/roger

install roger: `go get github.com/buchanae/roger/cmd/roger`

generate the funnel flags: `roger -tplfile ./cmd/util/flags.tpl -root Config ./config > cmd/util/flags.go`

Docs are generated from struct field comments. Support is added for getting all flags from environment variables.

I've done a quick test, and it seems to work, but haven't tested extensively.

Things to do:
- [ ] extensive testing
- [ ] split up worker/node/server flags, as they were before this PR
- [ ] do another pass on the doc strings

closes #252 