### PR TITLE
Optimize TaskStateCounts aggregate pipeline

### DIFF
--- a/database/mongodb/counts.go
+++ b/database/mongodb/counts.go
@@ -18,8 +18,8 @@ func (db *MongoDB) TaskStateCounts(ctx context.Context) (map[string]int32, error
 	defer sess.Close()
 
 	pipe := db.tasks(sess).Pipe([]bson.M{
-		bson.M{"$sort": bson.M{"state": 1}},
-		bson.M{"$group": bson.M{"_id": "$state", "count": bson.M{"$sum": 1}}},
+		{"$sort": bson.M{"state": 1}},
+		{"$group": bson.M{"_id": "$state", "count": bson.M{"$sum": 1}}},
 	})
 
 	recs := []stateCount{}

--- a/database/mongodb/counts.go
+++ b/database/mongodb/counts.go
@@ -18,7 +18,8 @@ func (db *MongoDB) TaskStateCounts(ctx context.Context) (map[string]int32, error
 	defer sess.Close()
 
 	pipe := db.tasks(sess).Pipe([]bson.M{
-		{"$group": bson.M{"_id": "$state", "count": bson.M{"$sum": 1}}},
+		bson.M{"$sort": bson.M{"state": 1}},
+		bson.M{"$group": bson.M{"_id": "$state", "count": bson.M{"$sum": 1}}},
 	})
 
 	recs := []stateCount{}


### PR DESCRIPTION
In its current state, MongoDB does not make use of indexes in $group operations within an aggregate pipeline.  If a lot of tasks exist in the db, this means that this simple aggregate -> sum operation will take a long time as it has to access all documents in the db and cannot just use an index. In real world usage, this was the longest frequently running query we noticed in the logs and it caused significant load on our db.

According to the [docs](https://docs.mongodb.com/manual/core/aggregation-pipeline/#aggregation-pipeline-operators-and-performance), $match and $sort both are capable of using said index, and inserting them at the beginning of the aggregate pipeline yields a roughly five and ten-fold decrease in query runtime, respectively (according to 1k test queries run by @kmavrommatis on our db). This happens because $group can then operate on the $match or $sort results rather than polling all the documents each time.

for additional reference, see discussion at https://jira.mongodb.org/browse/SERVER-29444 and related issues regarding the proposal of eventually allowing simple group calls like this to use covered indices.