### PR TITLE
Fix link to Kubernetes deployments in docs

### DIFF
--- a/deployments/kubernetes/README.md
+++ b/deployments/kubernetes/README.md
@@ -1,6 +1,6 @@
 # Using Funnel with Kubernetes
 
-Examples can be found here: https://github.com/ohsu-comp-bio/funnel/tree/kube/deployments/kubernetes
+Examples can be found here: https://github.com/ohsu-comp-bio/funnel/tree/master/deployments/kubernetes
 
 #### Create a Service:
 

--- a/docs/docs/compute/kubernetes/index.html
+++ b/docs/docs/compute/kubernetes/index.html
@@ -339,7 +339,7 @@
 <li><a href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings">Roles and RoleBindings</a></li>
 <li><a href="https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/">Job</a></li>
 </ul>
-<p>Additional Funnel deployment resources can be found here: <a href="https://github.com/ohsu-comp-bio/funnel/tree/kube/deployments/kubernetes">https://github.com/ohsu-comp-bio/funnel/tree/kube/deployments/kubernetes</a></p>
+<p>Additional Funnel deployment resources can be found here: <a href="https://github.com/ohsu-comp-bio/funnel/tree/master/deployments/kubernetes">https://github.com/ohsu-comp-bio/funnel/tree/master/deployments/kubernetes</a></p>
 <h4 id="create-a-service">Create a Service:</h4>
 <p><em>funnel-service.yml</em></p>
 <pre><code>apiVersion: v1

--- a/docs/docs/index.xml
+++ b/docs/docs/index.xml
@@ -211,7 +211,7 @@ EventWriters: - kafka - log Kafka: Servers: - localhost:9092 Topic: funnel-event
       <guid>https://ohsu-comp-bio.github.io/funnel/docs/compute/kubernetes/</guid>
       <description>Kubernetes This guide will take you through the process of setting up Funnel as a kubernetes service.
 Kuberenetes Resources:
- Service Deployment ConfigMap Roles and RoleBindings Job  Additional Funnel deployment resources can be found here: https://github.com/ohsu-comp-bio/funnel/tree/kube/deployments/kubernetes
+ Service Deployment ConfigMap Roles and RoleBindings Job  Additional Funnel deployment resources can be found here: https://github.com/ohsu-comp-bio/funnel/tree/master/deployments/kubernetes
 Create a Service: funnel-service.yml
 apiVersion: v1 kind: Service metadata: name: funnel spec: selector: app: funnel ports: - name: http protocol: TCP port: 8000 targetPort: 8000 - name: rpc protocol: TCP port: 9090 targetPort: 9090 Deploy it:</description>
     </item>

--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -330,12 +330,12 @@
 
   <div class="main col span_8_of_12">
     
-<h3>Download 0.10.0</h3>
+<h3>Download 0.10.1</h3>
 
 
 <ul>
-  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.10.0/funnel-linux-amd64-0.10.0.tar.gz">linux</a></li>
-  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.10.0/funnel-darwin-amd64-0.10.0.tar.gz">mac</a></li>
+  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.10.1/funnel-linux-amd64-0.10.1.tar.gz">linux</a></li>
+  <li><a href="https://github.com/ohsu-comp-bio/funnel/releases/download/0.10.1/funnel-darwin-amd64-0.10.1.tar.gz">mac</a></li>
   <li><small>Windows is not supported (yet), sorry!</small></li>
 </ul>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-us" lang="en-us">
 <head>
-	<meta name="generator" content="Hugo 0.64.0" />
+	<meta name="generator" content="Hugo 0.68.3" />
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -86,7 +86,7 @@ A node is a service which runs on each machine in a cluster. The node connects t
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://ohsu-comp-bio.github.io/funnel/download/</guid>
-      <description>Download 0.10.0  linux mac Windows is not supported (yet), sorry!  Funnel is a single binary.
+      <description>Download 0.10.1  linux mac Windows is not supported (yet), sorry!  Funnel is a single binary.
 Funnel requires Docker.
 Funnel is beta quality. APIs might break, bugs exist, data might be lost.
 Homebrew brew tap ohsu-comp-bio/formula brew install funnel In order to build the latest code, run:
@@ -224,7 +224,7 @@ EventWriters: - kafka - log Kafka: Servers: - localhost:9092 Topic: funnel-event
       <guid>https://ohsu-comp-bio.github.io/funnel/docs/compute/kubernetes/</guid>
       <description>Kubernetes This guide will take you through the process of setting up Funnel as a kubernetes service.
 Kuberenetes Resources:
- Service Deployment ConfigMap Roles and RoleBindings Job  Additional Funnel deployment resources can be found here: https://github.com/ohsu-comp-bio/funnel/tree/kube/deployments/kubernetes
+ Service Deployment ConfigMap Roles and RoleBindings Job  Additional Funnel deployment resources can be found here: https://github.com/ohsu-comp-bio/funnel/tree/master/deployments/kubernetes
 Create a Service: funnel-service.yml
 apiVersion: v1 kind: Service metadata: name: funnel spec: selector: app: funnel ports: - name: http protocol: TCP port: 8000 targetPort: 8000 - name: rpc protocol: TCP port: 9090 targetPort: 9090 Deploy it:</description>
     </item>

--- a/website/content/docs/compute/kubernetes.md
+++ b/website/content/docs/compute/kubernetes.md
@@ -17,7 +17,7 @@ Kuberenetes Resources:
 - [Roles and RoleBindings](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings)
 - [Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
 
-Additional Funnel deployment resources can be found here: https://github.com/ohsu-comp-bio/funnel/tree/kube/deployments/kubernetes
+Additional Funnel deployment resources can be found here: https://github.com/ohsu-comp-bio/funnel/tree/master/deployments/kubernetes
 
 #### Create a Service:
 


### PR DESCRIPTION
I found a broken link in the docs. This fixes it and rebuilds the website. It looks like the website build also picked up the latest release.