### PR TITLE
`fix/k8s` → `development`: Add Retry Logic to Executor Job and Logs

### DIFF
--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -162,12 +162,7 @@ func waitForPodRunning(ctx context.Context, namespace string, podName string, ti
 				return nil, fmt.Errorf("getting pod %s: %v", podName, err)
 			}
 
-			// Check if pod is in a terminal state
-			if pod.Status.Phase == corev1.PodRunning {
-				return pod, nil
-			} else if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
-				return nil, fmt.Errorf("pod %s is in a terminal state: %s", podName, pod.Status.Phase)
-			}
+			return pod, nil
 		}
 	}
 }

--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -98,7 +98,7 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 	if err != nil {
 		// Retry creating the Executor Pod on failure
 		var retryCount int
-		for retryCount < 3 {
+		for retryCount < 5 {
 			_, err = client.Create(ctx, job, metav1.CreateOptions{})
 			if err == nil {
 				break
@@ -107,7 +107,7 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 			time.Sleep(2 * time.Second)
 		}
 		if retryCount == 3 {
-			return fmt.Errorf("creating job in worker after 3 attempts: %v", err)
+			return fmt.Errorf("Funnel Worker: Failed to create Executor Job after 3 attempts: %v", err)
 		}
 	}
 
@@ -128,7 +128,7 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 		if err != nil {
 			// Retry reading the Executor Logs on failure
 			var retryCount int
-			for retryCount < 3 {
+			for retryCount < 5 {
 				podLogs, err := req.Stream(ctx)
 				if err == nil {
 					defer podLogs.Close()
@@ -143,8 +143,8 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 				retryCount++
 				time.Sleep(2 * time.Second)
 			}
-			if retryCount == 3 {
-				return fmt.Errorf("failed to read logs after 3 attempts: %v", err)
+			if retryCount == 5 {
+				return fmt.Errorf("Funnel Worker: Failed to read Executor Logs after 5 attempts: %v", err)
 			}
 			return err
 		}

--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -95,6 +95,7 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 	_, err = client.Create(ctx, job, metav1.CreateOptions{})
 
 	if err != nil {
+		// TODO: Retry creating the Exeuctor Pod on failure
 		return fmt.Errorf("creating job in worker: %v", err)
 	}
 
@@ -113,6 +114,7 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 		podLogs, err := req.Stream(ctx)
 
 		if err != nil {
+			// TODO: Retry reading the Executor Logs on failure
 			return err
 		}
 


### PR DESCRIPTION
# Overview ⚙️ 

When using the Kubernetes compute backend, the Funnel Worker fails when trying to read the logs of the Executor before the Executor Pod has fully started. This then results in a Error loop due to not having a retry mechanism in place. 

## Changes 🌀 

This PR resolves this issue by adding retry mechanisms in two places:

1. Creating the [Executor Job](https://github.com/ohsu-comp-bio/funnel/blob/develop/worker/kubernetes.go#L98)

2. Reading the [Executor Logs](https://github.com/ohsu-comp-bio/funnel/blob/develop/worker/kubernetes.go#L112-L117)

## Credits 🤝 

This PR is made possible by testing and development recommendations by the [CTDS Team](https://ctds.uchicago.edu/) of [Pauline Ribeyre](https://github.com/paulineribeyre), [Jawad Qureshi](https://github.com/jawadqur), [Aidan Hilt](https://github.com/AidanHilt), and [Ajo Augustine](https://github.com/ajoaugustine) as part of the [Gen3 Data Platform](https://gen3.org/) 🌱 