### PR TITLE
fix #1138: page token for ListTasks response on last page

### DIFF
--- a/tes/client.go
+++ b/tes/client.go
@@ -80,7 +80,10 @@ func (c *Client) ListTasks(ctx context.Context, req *ListTasksRequest) (*ListTas
 	// Build url query parameters
 	v := url.Values{}
 	addInt32(v, "page_size", req.GetPageSize())
-	addString(v, "page_token", req.GetPageToken())
+	pageToken := req.GetPageToken()
+	if pageToken != "" {
+		addString(v, "page_token", req.GetPageToken())
+	}
 	addString(v, "view", req.GetView())
 	addString(v, "name_prefix", req.GetNamePrefix())
 

--- a/tes/client.go
+++ b/tes/client.go
@@ -81,10 +81,14 @@ func (c *Client) ListTasks(ctx context.Context, req *ListTasksRequest) (*ListTas
 	v := url.Values{}
 	addInt32(v, "page_size", req.GetPageSize())
 	pageToken := req.GetPageToken()
+
+	// If pageToken is empty, don't add it to the URL
+	// ref: https://github.com/ga4gh/task-execution-schemas/blob/v1.1/openapi/task_execution_service.openapi.yaml#L506-L510
 	if pageToken != "" {
 		addString(v, "page_token", req.GetPageToken())
 	}
 	addString(v, "view", req.GetView())
+
 	addString(v, "name_prefix", req.GetNamePrefix())
 
 	if req.GetState() != Unknown {


### PR DESCRIPTION
# Overview 🌀 

This PR includes a minor (but important!) fix for how Funnel manages ListTask responses if on the last "page" of tasks.

## Current Behavior :x:

Funnel returns the `next_page_token` as an empty string ("") when there are no more pages to be read.

This can cause issues when testing this field (e.g. in [**client.rs**](https://github.com/stjude-rust-labs/tes/blob/main/src/v1/client.rs#L219-L231) of the [**tes crate**](https://crates.io/crates/tes)).

## New Behavior ✅ 

Funnel doesn't return the `next_page_token` if there are no more pages to be read.

# Credits 🤝 

Thanks to @claymcleod for spotting this issue!