### PR TITLE
`master` ← `fix/github-actions` — Update GitHub Actions workflows 🐛 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/ohsu-comp-bio/funnel
 
-go 1.22
-toolchain go1.23.1
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	cloud.google.com/go/datastore v1.15.0

--- a/tes/utils_test.go
+++ b/tes/utils_test.go
@@ -16,7 +16,7 @@ func TestBase64Encode(t *testing.T) {
 		},
 	}
 
-	expected := "ewogICJleGVjdXRvcnMiOiBbCiAgICB7CiAgICAgICJjb21tYW5kIjogWwogICAgICAgICJlY2hvIiwKICAgICAgICAiaGVsbG8gd29ybGQiCiAgICAgIF0sCiAgICAgICJpbWFnZSI6ICJhbHBpbmUiCiAgICB9CiAgXSwKICAiaWQiOiAidGFzazEiCn0="
+	expected := "ewogICJleGVjdXRvcnMiOiAgWwogICAgewogICAgICAiY29tbWFuZCI6ICBbCiAgICAgICAgImVjaG8iLAogICAgICAgICJoZWxsbyB3b3JsZCIKICAgICAgXSwKICAgICAgImltYWdlIjogICJhbHBpbmUiCiAgICB9CiAgXSwKICAiaWQiOiAgInRhc2sxIgp9"
 
 	encoded, err := Base64Encode(task)
 	if err != nil {


### PR DESCRIPTION
# Overview 🌀 

Cleaning up errors in the GitHub Actions workflows.

## Current Behavior ❌ 

Current Actions are failing on many workflows due to a mix of dependency issues (`go mod tidy`, deprecated fields).

## New Behavior ✅ 

All actions succeed for all tests defined in the [`.github/workflows`](https://github.com/ohsu-comp-bio/funnel/pull/1195/files) directory
